### PR TITLE
Implement Crouch State for Pilot

### DIFF
--- a/core_v2/actors/PilotAnimatorV2.gd
+++ b/core_v2/actors/PilotAnimatorV2.gd
@@ -20,6 +20,8 @@ const PARAM_LAND_TRANSITION_CURRENT = "parameters/Land/Transition/current"
 const PARAM_JUMP_TRANSITION_CURRENT = "parameters/Jump/Transition/current"
 const PARAM_PLAYBACK_ACTIVE = "parameters/playback/active"
 const PARAM_CONDITIONS_IS_ACROBATIC = "parameters/conditions/is_acrobatic"
+const PARAM_CONDITIONS_IS_CROUCHING = "parameters/conditions/is_crouching"
+const PARAM_CONDITIONS_NOT_CROUCHING = "parameters/conditions/!is_crouching"
 
 # --- EXPORTS ---
 # Velocidad de suavizado para la velocidad usada en el AnimationTree.
@@ -213,6 +215,11 @@ func update_animation_parameters(velocity: Vector3, is_on_floor: bool, move_vec_
 	# Actualizar condiciones básicas
 	animation_tree.set(PARAM_CONDITIONS_ON_FLOOR, is_on_floor)
 	animation_tree.set(PARAM_CONDITIONS_NOT_ON_FLOOR, not is_on_floor)
+
+	# Crouch State
+	var is_crouching = controller.is_crouching if "is_crouching" in controller else false
+	animation_tree.set(PARAM_CONDITIONS_IS_CROUCHING, is_crouching)
+	animation_tree.set(PARAM_CONDITIONS_NOT_CROUCHING, not is_crouching)
 
 	# Estados de salto/caída usando la velocidad registrada en el último frame en aire.
 	# IMPORTANTE: Forzamos false si estamos en el suelo (evita flickering en escaleras).

--- a/core_v2/input/InputDataV2.gd
+++ b/core_v2/input/InputDataV2.gd
@@ -6,6 +6,7 @@ class_name InputDataV2
 var move_vec := Vector2() # rango -1..1
 var jump := false
 var sprint := false
+var crouch := false
 var interact := false
 var mouse_delta := Vector2()
 var zoom_delta := 0.0
@@ -20,6 +21,7 @@ func to_dict() -> Dictionary:
 		"fov_override": fov_override,
 		"jump": jump,
 		"sprint": sprint,
+		"crouch": crouch,
 		"interact": interact
 	}
 
@@ -37,5 +39,7 @@ func from_dict(d: Dictionary) -> void:
 		jump = d["jump"]
 	if d.has("sprint"):
 		sprint = d["sprint"]
+	if d.has("crouch"):
+		crouch = d["crouch"]
 	if d.has("interact"):
 		interact = d["interact"]

--- a/core_v2/input/InputProviderV2.gd
+++ b/core_v2/input/InputProviderV2.gd
@@ -74,6 +74,7 @@ func _read_live_input() -> InputDataV2:
 
 		d.jump = Input.is_action_pressed("jump")
 		d.sprint = Input.is_action_pressed("run")
+		d.crouch = Input.is_action_pressed("crouch")
 		d.interact = Input.is_action_just_pressed("interact")
 
 		# --- JOYSTICK SPRINT (Left Stick) ---

--- a/core_v2/player/PlayerControllerV2.gd
+++ b/core_v2/player/PlayerControllerV2.gd
@@ -23,6 +23,11 @@ export(float) var min_pitch := -85.0
 export(float) var max_pitch := 85.0
 export(float) var interact_distance := 3.0
 
+# Crouch Configuration
+export(float) var capsule_height_standing := 2.0
+export(float) var capsule_height_crouch := 1.0
+export(float) var crouch_transition_speed := 10.0
+
 # Stair-stepping Configuration
 export(float) var step_height := 0.4
 export(float) var step_depth := 0.5
@@ -80,6 +85,9 @@ var last_input_vector := Vector3.ZERO
 var is_acrobatic_ready := false
 
 var _current_interactable: Node = null
+
+var is_crouching := false
+var _collision_shape: CollisionShape = null
 
 # Input
 var input_provider
@@ -171,6 +179,19 @@ onready var animator = $Visual/Pivot
 func _ready():
 	initial_transform = global_transform
 	add_to_group("player")
+
+	# Find CollisionShape
+	_collision_shape = get_node_or_null("CollisionShape")
+	if not _collision_shape:
+		# Fallback search
+		for i in range(get_child_count()):
+			if get_child(i) is CollisionShape:
+				_collision_shape = get_child(i)
+				break
+
+	if _collision_shape and _collision_shape.shape:
+		_collision_shape.shape = _collision_shape.shape.duplicate()
+
 	input_provider = InputProviderV2.new()
 
 	if has_node("Logic/Jump"):
@@ -568,7 +589,36 @@ func step(dt: float, input: InputDataV2) -> void:
 		# Simplify input to just "forward" magnitude for the logic
 		move_vec = Vector2(0, -world_dir.length())
 	
-	movement_logic.process_movement(dt, move_vec, basis, input.sprint, is_on_floor())
+	# --- CROUCH LOGIC ---
+	var wish_crouch = input.crouch and is_on_floor()
+
+	# Ceiling check when trying to stand up
+	if is_crouching and not wish_crouch:
+		# Raycast upwards from center (approx)
+		var space_state = get_world().direct_space_state
+		# We use the full standing height for the check
+		var result = space_state.intersect_ray(global_transform.origin, global_transform.origin + Vector3.UP * capsule_height_standing, [self], collision_mask)
+		if not result.empty():
+			wish_crouch = true # Forced crouch
+
+	is_crouching = wish_crouch
+
+	# Physics Interpolation
+	if _collision_shape and _collision_shape.shape is CapsuleShape:
+		var radius = _collision_shape.shape.radius
+		var target_total_height = capsule_height_crouch if is_crouching else capsule_height_standing
+		var target_shape_height = max(0.01, target_total_height - 2.0 * radius)
+
+		var current_shape_height = _collision_shape.shape.height
+		var new_shape_height = lerp(current_shape_height, target_shape_height, crouch_transition_speed * dt)
+		_collision_shape.shape.height = new_shape_height
+
+		_collision_shape.transform.origin.y = radius + new_shape_height * 0.5
+
+	# Priority: Crouch cancels sprint
+	var effective_sprint = input.sprint and not is_crouching
+
+	movement_logic.process_movement(dt, move_vec, basis, effective_sprint, is_on_floor(), is_crouching)
 	
 	var h_vel = movement_logic.get_horizontal_velocity()
 	velocity.x = h_vel.x

--- a/core_v2/player/PlayerMovementV2.gd
+++ b/core_v2/player/PlayerMovementV2.gd
@@ -7,6 +7,7 @@ export(float) var ground_friction := 30.0
 export(float) var air_friction := 10.0
 export(float) var move_speed := 5.0
 export(float) var run_speed_multiplier := 1.8
+export(float) var crouch_speed_multiplier := 0.5
 export(float) var air_control_multiplier := 0.5 # Reducir aceleración en el aire
 export(float) var stop_threshold := 0.01 # Threshold para forzar velocidad a cero
 
@@ -162,8 +163,14 @@ func restore_snapshot(data: Dictionary) -> void:
 	is_tank_turn_mode = data.get("is_tank_turn_mode", true)
 	current_turn_time = data.get("current_turn_time", 0.0)
 
-func process_movement(dt: float, move_vec: Vector2, basis: Basis, sprint: bool, is_on_floor: bool) -> void:
-	var target_speed = move_speed * (run_speed_multiplier if sprint else 1.0)
+func process_movement(dt: float, move_vec: Vector2, basis: Basis, sprint: bool, is_on_floor: bool, crouch: bool = false) -> void:
+	var multiplier = 1.0
+	if crouch:
+		multiplier = crouch_speed_multiplier
+	elif sprint:
+		multiplier = run_speed_multiplier
+
+	var target_speed = move_speed * multiplier
 	
 	var forward = - basis.z
 	forward.y = 0.0

--- a/core_v2/systems/OYS_Interpreter.gd
+++ b/core_v2/systems/OYS_Interpreter.gd
@@ -537,6 +537,24 @@ func _execute_instruction(inst: Dictionary, my_id: int):
 			if __state_fov is GDScriptFunctionState:
 				yield (__state_fov, "completed")
 		
+		"INPUT_PRESS":
+			var action = inst.get("action", "")
+			if action != "":
+				var session = host_node.get_node_or_null("/root/SessionManager")
+				if session:
+					if not session.get("_oys_input_override"):
+						session.set("_oys_input_override", {})
+					session.get("_oys_input_override")[action] = true
+					print("[OYS] INPUT_PRESS ", action)
+
+		"INPUT_RELEASE":
+			var action = inst.get("action", "")
+			if action != "":
+				var session = host_node.get_node_or_null("/root/SessionManager")
+				if session and session.get("_oys_input_override"):
+					session.get("_oys_input_override")[action] = false
+					print("[OYS] INPUT_RELEASE ", action)
+
 		# Markers - no action needed
 		"LEVEL", "END":
 			pass
@@ -1126,6 +1144,24 @@ func _resolve_value(val: String):
 		return variables.get(val, 0)
 	if val.is_valid_float():
 		return val.to_float()
+	if val == "pilot_height":
+		var player = _find_player()
+		if player and is_instance_valid(player):
+			# Try finding CollisionShape to get current height
+			var shape_node = player.get_node_or_null("CollisionShape")
+			if not shape_node:
+				# Fallback
+				shape_node = player.find_node("CollisionShape", true, false)
+
+			if shape_node and shape_node.shape:
+				if shape_node.shape is CapsuleShape:
+					return shape_node.shape.height
+				elif shape_node.shape is CylinderShape:
+					return shape_node.shape.height
+				# BoxShape?
+				return 0.0
+		return 0.0
+
 	if val in ["pos.y", "pos.x", "pos.z"]:
 		var player = _find_player()
 		if not is_instance_valid(player):

--- a/core_v2/tests/test_crouch.oys
+++ b/core_v2/tests/test_crouch.oys
@@ -1,0 +1,30 @@
+SECTION "CrouchTest"
+    # Basic Setup: Move to safe spot
+    SET pos (0, 10, 0)
+    WAIT 1.0
+
+    # Assert Standing Height (Capsule Height ~ 1.0)
+    PRINT "Checking standing height..."
+    PRINT "Current Height: $pilot_height"
+    ASSERT pilot_height > 0.8
+
+    # Crouch
+    PRINT "Pressing crouch..."
+    INPUT_PRESS "crouch"
+    WAIT 1.0
+
+    # Assert Crouched Height (Capsule Height ~ 0.0)
+    PRINT "Checking crouched height..."
+    PRINT "Current Height: $pilot_height"
+    ASSERT pilot_height < 0.2
+
+    # Release
+    PRINT "Releasing crouch..."
+    INPUT_RELEASE "crouch"
+    WAIT 1.0
+
+    # Assert Standing Again
+    PRINT "Checking return to standing..."
+    PRINT "Current Height: $pilot_height"
+    ASSERT pilot_height > 0.8
+END

--- a/project.godot
+++ b/project.godot
@@ -1672,6 +1672,7 @@ toggle_debug_menu={
 crouch={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":67,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777238,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 interact={


### PR DESCRIPTION
Implemented the requested Crouch mechanic for the Pilot character.

Changes:
- **Input:** Added `crouch` action to `project.godot` (Keys: C, Control) and updated `InputProviderV2` to read it.
- **Physics (`PlayerControllerV2`):**
    - Added `is_crouching` state.
    - Implemented logic to resize `CollisionShape` (Capsule) height via linear interpolation.
    - Added logic to adjust vertical offset (`translation.y`) to keep feet on the ground during resize.
    - Added ceiling check (RayCast) to prevent standing up if obstructed.
    - Prioritized crouching over sprinting.
- **Animation (`PilotAnimatorV2`):**
    - Exposed `is_crouching` parameter to the AnimationTree.
- **Testing (`OYS_Interpreter`):**
    - Added `INPUT_PRESS` and `INPUT_RELEASE` commands to inject persistent input state for tests.
    - Added `pilot_height` variable resolution to allow assertions on collision shape height.
    - Added verification test `core_v2/tests/test_crouch.oys`.

---
*PR created automatically by Jules for task [17621791940560732714](https://jules.google.com/task/17621791940560732714) started by @icarito*