### PR TITLE
Fix CargolDroneV2 registration hack with signal-based system

### DIFF
--- a/core_v2/actors/CargolDroneV2.gd
+++ b/core_v2/actors/CargolDroneV2.gd
@@ -63,8 +63,11 @@ func _ready():
 
 	# Register as OYS Actor
 	var sm = get_node_or_null("/root/SessionManager")
-	if sm and sm.has_method("register_oys_actor"):
-		sm.register_oys_actor("CargolDrone", self)
+	if sm:
+		if sm.has_method("register_oys_actor"):
+			sm.register_oys_actor("CargolDrone", self)
+		if sm.has_signal("oys_registry_reset"):
+			sm.connect("oys_registry_reset", self, "_on_oys_registry_reset")
 
 	# Register with Performance Monitor
 	if Engine.has_singleton("PerformanceMonitor") or has_node("/root/PerformanceMonitor"):
@@ -320,13 +323,6 @@ func step(dt: float) -> void:
 		_perf_monitor.measure_end(self, "step")
 
 func _process(_delta):
-	# Ensure registration persists (hack for replay mode re-registration)
-	if not get_tree().get_nodes_in_group("oys_actor").has(self):
-		add_to_group("oys_actor")
-		var sm = get_node_or_null("/root/SessionManager")
-		if sm and sm.has_method("register_oys_actor"):
-			sm.register_oys_actor("CargolDrone", self)
-
 	# Move and Slide
 	if velocity.length() > 0.001:
 		velocity = move_and_slide(velocity, Vector3.UP)
@@ -349,6 +345,11 @@ func _process(_delta):
 			var target_look = global_transform.origin + horiz_vel.normalized()
 			if not target_look.is_equal_approx(global_transform.origin):
 				look_at(target_look, Vector3.UP)
+
+func _on_oys_registry_reset() -> void:
+	var sm = get_node_or_null("/root/SessionManager")
+	if sm and sm.has_method("register_oys_actor"):
+		sm.register_oys_actor("CargolDrone", self)
 
 # --- VISUAL FEEDBACK ---
 

--- a/core_v2/autoloads/SessionManager.gd
+++ b/core_v2/autoloads/SessionManager.gd
@@ -4,6 +4,7 @@ var _is_validating := false # Re-entry protection
 var _replay_watchdog_frames := 0 # Safety counter for tests
 
 signal replay_finished(success, drift, frames)
+signal oys_registry_reset
 
 var player: KinematicBody = null
 var _player_searched = false
@@ -676,6 +677,7 @@ func load_and_play(path: String):
 	_oys_requested_scene = ""
 	_peak_y = -999.0
 	_oys_actors = {}
+	emit_signal("oys_registry_reset")
 	_replay_input_provider = null
 	_replay_input_buffer.clear()
 	_cleanup_session_spawned_nodes()
@@ -2039,6 +2041,8 @@ func register_oys_actor(name: String, node: Node) -> void:
 		printerr("[SessionManager] Attempted to register invalid actor: ", name)
 		return
 	_oys_actors[name] = node
+	if not node.is_in_group("oys_actor"):
+		node.add_to_group("oys_actor")
 	print("[SessionManager] OYS Actor Registered: ", name, " -> ", node.name)
 
 func get_oys_actor(name: String) -> Node:
@@ -2052,6 +2056,9 @@ func get_oys_actor(name: String) -> Node:
 
 func unregister_oys_actor(name: String) -> void:
 	if _oys_actors.has(name):
+		var node = _oys_actors[name]
+		if is_instance_valid(node) and node.is_in_group("oys_actor"):
+			node.remove_from_group("oys_actor")
 		_oys_actors.erase(name)
 
 func take_oys_screenshot(label: String, _extra = ""):


### PR DESCRIPTION
This PR replaces a hack in `CargolDroneV2` where it was checking every frame if it was registered in `SessionManager`'s OYS actor registry. This behavior was necessary because `SessionManager` clears the registry during `load_and_play`, potentially orphaning persistent actors.

The fix introduces a `oys_registry_reset` signal in `SessionManager` that is emitted when the registry is wiped. `CargolDroneV2` now listens for this signal and re-registers itself cleanly. Additionally, group membership management ("oys_actor") has been moved into `SessionManager` to ensure consistency.

---
*PR created automatically by Jules for task [1542811033333958935](https://jules.google.com/task/1542811033333958935) started by @icarito*