### PR TITLE
feat: Optional nodes system for low-end platform support

### DIFF
--- a/addons/gd-shader-cache/plugin.cfg
+++ b/addons/gd-shader-cache/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="gd-shader-cache"
+description=""
+author="imjp94"
+version=""
+script="plugin.gd"

--- a/addons/gd-shader-cache/plugin.gd
+++ b/addons/gd-shader-cache/plugin.gd
@@ -1,0 +1,9 @@
+tool
+extends EditorPlugin
+
+const ShaderCache = preload("res://addons/gd-shader-cache/src/ShaderCache.gd")
+
+
+func _enter_tree():
+	add_custom_type("ShaderCache", "Spatial", ShaderCache, null)
+	add_autoload_singleton("ShaderCacheManager", "res://addons/gd-shader-cache/src/ShaderCacheManager.gd")

--- a/addons/gd-shader-cache/src/ShaderCache.gd
+++ b/addons/gd-shader-cache/src/ShaderCache.gd
@@ -1,0 +1,323 @@
+# Based on https://gist.github.com/ViniciusMeirelles/7ef55b9bfec7f3b5e3448b1a7a63b5ef
+tool
+extends Spatial
+
+signal compiled()
+
+export var cache_scene_btn = false setget cache_scene
+export var clear_cache_btn = false setget clear_cache
+
+export var active = true setget set_active
+export(String, FILE, "*.tscn, *.scn") var scene_path = ""
+export var cache_packed_scene_recusively = true # Cache every PackedScene from script variable
+export var cache_material_in_animation_player = true # Cache every unique materials from animation key
+export var active_frame_count = 2
+
+var local_to_scene_materials_node setget, get_local_to_scene_materials_node
+var materials_node setget , get_materials_node
+var particles_materials_node setget , get_particles_materials_node
+var skeleton_node setget , get_skeleton_node
+
+var _virtual_tree
+var _frame_countdown = 0
+var _quad_mesh
+var _multi_mesh
+var _materials = []
+var _particles_materials = {}
+var _meshes = {}
+
+
+func _ready():
+	if Engine.editor_hint:
+		return
+	
+	set_active(active)
+
+func _process(delta):
+	if Engine.editor_hint:
+		return
+	
+	if _frame_countdown > 0:
+		_frame_countdown -= 1
+	else:
+		emit_signal("compiled")
+		set_active(false)
+
+func emit_particles():
+	particles_materials_node = get_particles_materials_node()
+	if particles_materials_node:
+		for particles in particles_materials_node.get_children():
+			particles.emitting = true
+
+func cache_scene(value=true):
+	clear_cache()
+	_virtual_tree = SceneTree.new()
+	_virtual_tree.init()
+	_virtual_tree.get_root().set_update_mode(Viewport.UPDATE_DISABLED)
+
+	# Wait for 2 frames, making sure nodes are freed after clear_cache()
+	yield(get_tree(), "idle_frame")
+	yield(get_tree(), "idle_frame")
+
+	_quad_mesh = QuadMesh.new()
+	_multi_mesh = MultiMesh.new()
+	_multi_mesh.mesh = _quad_mesh
+	_multi_mesh.instance_count = 1
+	var packed_scene = load(scene_path)
+	_cache_scene(packed_scene)
+
+	local_to_scene_materials_node = get_local_to_scene_materials_node()
+	if local_to_scene_materials_node:
+		print("ShaderCache: Local to scene materials found(%d), " % local_to_scene_materials_node.get_child_count() + 
+		"hover on children of `LocalToSceneMaterials` to check their origin or read from editor_description" )
+	
+	_virtual_tree.finish()
+	_virtual_tree.free()
+	_materials.clear()
+	_particles_materials.clear()
+
+func clear_cache(value=true):
+	_materials.clear()
+	_particles_materials.clear()
+	_meshes.clear()
+	var to_free = []
+	to_free.append(get_node_or_null("LocalToSceneMaterials"))
+	to_free.append(get_node_or_null("Materials"))
+	to_free.append(get_node_or_null("ParticlesMaterials"))
+	to_free.append(get_node_or_null("Skeleton"))
+	for node in to_free:
+		if node == null:
+			continue
+
+		node.queue_free()
+
+func _cache_scene(packed_scene):
+	var scene = packed_scene.instance()
+	_virtual_tree.root.add_child(scene)
+	_cache_node(scene, {"owner_path": packed_scene.resource_path})
+	scene.queue_free()
+
+func _cache_node(node, extra={}):
+	if cache_packed_scene_recusively:
+		for property in node.get_property_list():
+			if property.type == TYPE_OBJECT and property.usage & PROPERTY_USAGE_SCRIPT_VARIABLE:
+				var property_value = node.get(property.name)
+				if property_value is PackedScene:
+					_cache_scene(property_value)
+	
+	if node is AnimationPlayer and cache_material_in_animation_player:
+		var anim_player_root_node = node.get_node(node.root_node)
+		for animation_name in node.get_animation_list():
+			var animation = node.get_animation(animation_name)
+			for track_idx in animation.get_track_count():
+				for key_idx in animation.track_get_key_count(track_idx):
+					var key_value = animation.track_get_key_value(track_idx, key_idx)
+					if key_value is Material:
+						var node_and_resource = anim_player_root_node.get_node_and_resource(animation.track_get_path(track_idx))
+						_cache_material(node_and_resource[0], key_value, extra)
+	
+	if node is GeometryInstance:
+		if node.material_override != null:
+			var material = node.material_override
+			_cache_material(node, material, extra)
+		
+		if node.material_overlay != null:
+			var material = node.material_overlay
+			_cache_material(node, material, extra)
+		
+		if node is MeshInstance:
+			if node.get_surface_material_count() > 0:
+				for i in node.get_surface_material_count():
+					var material = node.get_surface_material(i)
+					_cache_material(node, material, extra)
+			
+			if node.mesh:
+				for i in node.mesh.get_surface_count():
+					var material = node.mesh.surface_get_material(i)
+					_cache_material(node, material, extra)
+		
+		if node is CSGPrimitive:
+			if "material" in node:
+				var material = node.get_material()
+				_cache_material(node, material, extra)
+	
+	if node is Particles:
+		if node.process_material != null:
+			var material = node.material_override
+			var proc_mat = node.process_material
+			_cache_particle_material(node, material, proc_mat, extra)
+	
+	for child in node.get_children():
+		if node.get_script():
+			if node.get_script().get_path() == get_script().get_path(): # Ignore ShaderCache
+				continue
+		
+		if is_instance_valid(child):
+			_cache_node(child, extra)
+
+func _cache_material(node, material, extra={}):
+	if not material:
+		return
+
+	if not _materials.has(material):
+		_materials.append(material)
+	else:
+		return
+
+	var geometry_instance
+	if node is MultiMeshInstance:
+		geometry_instance = new_multi_mesh_instance(node, material)
+	elif node is GeometryInstance:
+		geometry_instance = new_mesh_instance(node, material)
+	
+	if geometry_instance:
+		var parent
+		if node.get_parent() is Skeleton:
+			parent = get_skeleton_node(true)
+		else:
+			if material.resource_local_to_scene:
+				var from_node_path_string = String(node.get_path()).lstrip("/root/")
+				var from_node_owner_path = extra.get("owner_path")
+				parent = get_local_to_scene_materials_node(true)
+				geometry_instance.editor_description = "Owner: %s\nNodePath: %s" % [from_node_owner_path, from_node_path_string]
+			else:
+				parent = get_materials_node(true)
+		
+		if parent:
+			parent.add_child(geometry_instance)
+			geometry_instance.set_owner(self)
+
+# Add the process material and the material from particles
+func _cache_particle_material(node, material, proc_mat, extra={}):
+	var draw_passes_list = _particles_materials.get(proc_mat)
+	if draw_passes_list:
+		# Ignore material if already loaded, taking both process material and draw passes into consideration
+		for draw_passes in draw_passes_list:
+			if draw_passes.size() == node.draw_passes:
+				var is_cached = true
+				for i in draw_passes.size():
+					var node_draw_pass = node.get_draw_pass_mesh(i)
+					var draw_pass = draw_passes[i]
+					is_cached = is_cached and draw_pass == node_draw_pass
+				if is_cached:
+					return
+	else:
+		draw_passes_list = []
+		_particles_materials[proc_mat] = draw_passes_list
+	
+	if node.preprocess > 0:
+		var from_node_path_string = String(node.get_path()).lstrip("/root/")
+		var from_node_owner_path = extra.get("owner_path")
+		print("ShaderCache: Particles with preprocess > 0 will not be cached properly, please set preprocess to 0. ", 
+		"Owner: %s, NodePath: %s" % [from_node_owner_path, from_node_path_string]
+		)
+
+	var draw_passes = []
+	for i in node.draw_passes:
+		draw_passes.append(node.get_draw_pass_mesh(i))
+	draw_passes_list.append(draw_passes)
+	var particles = new_particles(node, material, proc_mat)
+	get_particles_materials_node(true).add_child(particles)
+	particles.set_owner(self)
+
+# Create mesh instance for any class inherited from GeometryInstance
+func new_mesh_instance(node, material):
+	var mesh_instance = MeshInstance.new()
+	mesh_instance.mesh = _quad_mesh
+	if "mesh" in node:
+		if node.mesh is ArrayMesh: # MeshInstance must use original mesh if it is ArrayMesh
+			var mesh = node.mesh
+			var is_cached = true
+			# Ignore array mesh if already loaded, taking both array mesh and materials into consideration
+			if mesh in _meshes:
+				var material_list = _meshes[mesh]
+				if not material_list.has(material):
+					material_list.append(material)
+					is_cached = false
+			else:
+				_meshes[mesh] = [material]
+				is_cached = false
+			
+			if not is_cached:
+				mesh_instance.mesh = node.mesh
+	mesh_instance.material_override = material
+	mesh_instance.name = node.name
+	mesh_instance.cast_shadow = node.cast_shadow
+	return mesh_instance
+
+func new_multi_mesh_instance(node, material):
+	var multimesh = MultiMeshInstance.new()
+	multimesh.multimesh = _multi_mesh
+	multimesh.material_override = material
+	multimesh.name = node.name
+	multimesh.cast_shadow = node.cast_shadow
+	return multimesh
+
+func new_particles(node, material, proc_mat):
+	var particles = Particles.new()
+	particles.lifetime = 0.1
+	particles.one_shot = true
+	particles.emitting = false
+	particles.draw_passes = node.draw_passes
+	for i in node.draw_passes:
+		particles.set_draw_pass_mesh(i, node.get_draw_pass_mesh(i))
+	particles.process_material = proc_mat
+	particles.name = node.name
+	particles.cast_shadow = node.cast_shadow
+	particles.material_override = material
+	return particles
+
+func set_active(v):
+	active = v
+	visible = active
+	if Engine.editor_hint:
+		return
+	
+	set_process(active)
+	if active:
+		_frame_countdown = active_frame_count
+		emit_particles()
+
+func get_local_to_scene_materials_node(create_if_null=false):
+	if not is_instance_valid(local_to_scene_materials_node):
+		local_to_scene_materials_node = get_node_or_null("LocalToSceneMaterials")
+		if not local_to_scene_materials_node and create_if_null:
+			local_to_scene_materials_node = Spatial.new()
+			local_to_scene_materials_node.name = "LocalToSceneMaterials"
+			add_child(local_to_scene_materials_node)
+			move_child(local_to_scene_materials_node, 0)
+			local_to_scene_materials_node.owner = self
+	return local_to_scene_materials_node
+
+func get_materials_node(create_if_null=false):
+	if not is_instance_valid(materials_node):
+		materials_node = get_node_or_null("Materials")
+		if not materials_node and create_if_null:
+			materials_node = Spatial.new()
+			materials_node.name = "Materials"
+			add_child(materials_node)
+			move_child(materials_node, int(min(get_child_count(), 1)))
+			materials_node.owner = self
+	return materials_node
+
+func get_particles_materials_node(create_if_null=false):
+	if not is_instance_valid(particles_materials_node):
+		particles_materials_node = get_node_or_null("ParticlesMaterials")
+		if not particles_materials_node and create_if_null:
+			particles_materials_node = Spatial.new()
+			particles_materials_node.name = "ParticlesMaterials"
+			add_child(particles_materials_node)
+			move_child(particles_materials_node, int(min(get_child_count(), 2)))
+			particles_materials_node.owner = self
+	return particles_materials_node
+
+func get_skeleton_node(create_if_null=false):
+	if not is_instance_valid(skeleton_node):
+		skeleton_node = get_node_or_null("Skeleton")
+		if not skeleton_node and create_if_null:
+			skeleton_node = Skeleton.new()
+			skeleton_node.name = "Skeleton"
+			add_child(skeleton_node)
+			move_child(skeleton_node, int(min(get_child_count(), 3)))
+			skeleton_node.owner = self
+	return skeleton_node

--- a/addons/gd-shader-cache/src/ShaderCacheManager.gd
+++ b/addons/gd-shader-cache/src/ShaderCacheManager.gd
@@ -1,0 +1,50 @@
+extends Spatial
+
+signal compiled(cache_path)
+
+var camera = Camera.new()
+
+var _compiled_cache_paths = []
+
+
+func _ready():
+	camera.current = false
+	add_child(camera)
+
+func load_and_compile(cache_path):
+	var cache_packed_scene = load(cache_path)
+	compile(cache_packed_scene)
+
+func compile(cache_packed_scene):
+	var cache_path = cache_packed_scene.resource_path
+	if is_compiled(cache_path):
+		return
+	
+	var cache_scene = spawn_cache(cache_packed_scene)
+	cache_scene.connect("compiled", self, "_on_cache_compiled", [cache_path, cache_scene])
+
+func spawn_cache(cache_packed_scene):
+	var cache_scene = cache_packed_scene.instance()
+	var active_camera = get_active_camera()
+	active_camera.add_child(cache_scene)
+	cache_scene.scale = Vector3.ONE * 0.001
+	cache_scene.global_transform.origin = -active_camera.global_transform.basis.z * 5
+
+	return cache_scene
+
+func is_compiled(cache_path):
+	return cache_path in _compiled_cache_paths
+
+func _on_cache_compiled(cache_path, cache_scene):
+	camera.current = false
+	_compiled_cache_paths.append(cache_path)
+	cache_scene.queue_free()
+	emit_signal("compiled", cache_path)
+
+func get_active_camera():
+	var active_camera = get_viewport().get_camera()
+	if not active_camera:
+		active_camera = camera
+		camera.current = true
+
+	return active_camera

--- a/core_v2/actors/Pilot_v2.tscn
+++ b/core_v2/actors/Pilot_v2.tscn
@@ -123,7 +123,7 @@ monitorable = false
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, -1.5 )
 shape = SubResource( 120 )
 
-[node name="FakeShadow" type="MeshInstance" parent="Visual/Pivot"]
+[node name="FakeShadow" type="MeshInstance" parent="Visual/Pivot" groups=["optional"]]
 cast_shadow = 0
 script = ExtResource( 53 )
 grid_resolution = 12
@@ -135,7 +135,7 @@ script = ExtResource( 14 )
 audio_stream = ExtResource( 13 )
 trigger_mode = "OneShotActive"
 
-[node name="OmniLight" type="OmniLight" parent="Visual"]
+[node name="OmniLight" type="OmniLight" parent="Visual" groups=["optional"]]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 0 )
 light_energy = 0.342
 light_specular = 0.4

--- a/core_v2/autoloads/OptionalNodeManager.gd
+++ b/core_v2/autoloads/OptionalNodeManager.gd
@@ -1,0 +1,69 @@
+extends Node
+
+var _optional_enabled: bool = true
+var _config_loaded: bool = false
+
+signal optional_nodes_toggled(enabled: bool)
+
+func _ready() -> void:
+	_load_config()
+	_register_input_actions()
+	_apply_initial_state()
+
+func _load_config() -> void:
+	var config = ProjectSettings.get_setting("application/config/optional_nodes_enabled", true)
+	_optional_enabled = config
+	_config_loaded = true
+
+func _register_input_actions() -> void:
+	if not InputMap.has_action("toggle_optional_nodes"):
+		var event = InputEventKey.new()
+		event.scancode = KEY_F10
+		InputMap.add_action("toggle_optional_nodes")
+		InputMap.action_add_event("toggle_optional_nodes", event)
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("toggle_optional_nodes"):
+		toggle_optional_nodes()
+
+func _apply_initial_state() -> void:
+	_update_all_optional_nodes()
+
+func _update_all_optional_nodes() -> void:
+	var optional_nodes = get_tree().get_nodes_in_group("optional")
+	for node in optional_nodes:
+		_set_node_optional_state(node, _optional_enabled)
+	emit_signal("optional_nodes_toggled", _optional_enabled)
+
+func _set_node_optional_state(node: Node, enabled: bool) -> void:
+	if node is Spatial:
+		node.visible = enabled
+	if node is CanvasItem:
+		node.visible = enabled
+	if node.has_method("set_process"):
+		node.set_process(enabled)
+	if node.has_method("set_physics_process"):
+		node.set_physics_process(enabled)
+	if node is CollisionObject:
+		if enabled:
+			node.set_deferred("monitoring", true)
+			node.set_deferred("monitorable", true)
+		else:
+			node.set_deferred("monitoring", false)
+			node.set_deferred("monitorable", false)
+
+func toggle_optional_nodes() -> void:
+	_optional_enabled = not _optional_enabled
+	_update_all_optional_nodes()
+	print("[OptionalNodeManager] Optional nodes: ", "ENABLED" if _optional_enabled else "DISABLED")
+
+func set_optional_nodes_enabled(enabled: bool) -> void:
+	if _optional_enabled != enabled:
+		_optional_enabled = enabled
+		_update_all_optional_nodes()
+
+func is_optional_enabled() -> bool:
+	return _optional_enabled
+
+func get_optional_node_count() -> int:
+	return get_tree().get_nodes_in_group("optional").size()

--- a/core_v2/autoloads/OptionalNodeManager.gd
+++ b/core_v2/autoloads/OptionalNodeManager.gd
@@ -3,7 +3,7 @@ extends Node
 var _optional_enabled: bool = true
 var _config_loaded: bool = false
 
-signal optional_nodes_toggled(enabled: bool)
+signal optional_nodes_toggled(enabled)
 
 func _ready() -> void:
 	_load_config()
@@ -11,8 +11,10 @@ func _ready() -> void:
 	_apply_initial_state()
 
 func _load_config() -> void:
-	var config = ProjectSettings.get_setting("application/config/optional_nodes_enabled", true)
-	_optional_enabled = config
+	if ProjectSettings.has_setting("application/config/optional_nodes_enabled"):
+		_optional_enabled = ProjectSettings.get_setting("application/config/optional_nodes_enabled")
+	else:
+		_optional_enabled = true
 	_config_loaded = true
 
 func _register_input_actions() -> void:

--- a/core_v2/levels/BaseTerrace.tscn
+++ b/core_v2/levels/BaseTerrace.tscn
@@ -1793,10 +1793,10 @@ mesh = SubResource( 674 )
 transform = Transform( 1, 0, -7.10543e-15, 0, 1, 0, 7.10543e-15, 0, 1, 0.310929, -0.59305, -0.0207176 )
 shape = SubResource( 675 )
 
-[node name="VerticalDoor" parent="Building" groups=["no_occlusion"] instance=ExtResource( 26 )]
+[node name="VerticalDoor" parent="Building" groups=["no_occlusion", "optional"] instance=ExtResource( 26 )]
 transform = Transform( 1.19249e-08, 0, -1, 0, 1, 0, 1, 0, 1.19249e-08, -11.0076, 6.003, 28.6455 )
 
-[node name="OcclusionArea" type="Area" parent="Building"]
+[node name="OcclusionArea" type="Area" parent="Building" groups=["optional"]]
 transform = Transform( 1.80496, 0, 0, 0, 1.80717, 0, 0, 0, 3.52709, -22, 0, 20.5809 )
 collision_mask = 2
 script = ExtResource( 27 )
@@ -1817,7 +1817,7 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -25.3912, 20.017, 32.3357 )
 debug_render = false
 zone_extents = Vector3( 2.2, 4, 1 )
 
-[node name="InteriorWide" parent="." instance=ExtResource( 32 )]
+[node name="InteriorWide" parent="." groups=["optional"] instance=ExtResource( 32 )]
 
 [node name="DirectionalLight" parent="InteriorWide" index="0"]
 transform = Transform( -0.315579, 0.252033, -0.914757, -0.125866, 0.951167, 0.30541, 0.940509, 0.211516, -0.265529, 0.464873, 30.9615, 3.10425 )
@@ -2056,19 +2056,19 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.04532, 0 )
 script = ExtResource( 42 )
 _scenes = [ ExtResource( 43 ) ]
 
-[node name="PushableBoxV20" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV20" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.0871558, 0, 0.996195, 0, 1, 0, -0.996195, 0, -0.0871558, 11.8642, 0.55998, -23.3153 )
 
-[node name="PushableBoxV21" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV21" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.0523359, 0, 0.99863, 0, 1, 0, -0.99863, 0, -0.0523359, 7.767, 0.55998, -19.6823 )
 
-[node name="PushableBoxV22" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV22" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.788011, 0, -0.615661, 0, 1, 0, 0.615661, 0, -0.788011, 4.0169, 0.55998, -19.4936 )
 
-[node name="PushableBoxV23" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV23" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.999848, 0, 0.0174525, 0, 1, 0, -0.0174525, 0, -0.999848, 11.5733, 0.55998, -20.7082 )
 
-[node name="PushableBoxV24" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV24" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.999848, 0, 0.0174525, 0, 1, 0, -0.0174525, 0, -0.999848, 11.5733, 3.70528, -20.7082 )
 
 [node name="PushableBoxV2" parent="Scatter3D" instance=ExtResource( 43 )]
@@ -2077,52 +2077,52 @@ transform = Transform( -0.857167, 0, 0.515038, 0, 1, 0, -0.515038, 0, -0.857167,
 [node name="PushableBoxV3" parent="Scatter3D" instance=ExtResource( 43 )]
 transform = Transform( 0.999848, 0, -0.0174524, 0, 1, 0, 0.0174524, 0, 0.999848, 3.385, 0.55998, -27.7067 )
 
-[node name="PushableBoxV4" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV4" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.956305, 0, 0.292372, 0, 1, 0, -0.292372, 0, -0.956305, 3.6921, 0.55998, -23.3992 )
 
-[node name="PushableBoxV5" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV5" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.798635, 0, -0.601815, 0, 1, 0, 0.601815, 0, -0.798635, 6.1763, 0.55998, -22.1258 )
 
 [node name="PushableBoxV6" parent="Scatter3D" instance=ExtResource( 43 )]
 transform = Transform( -0.951056, 0, -0.309017, 0, 1, 0, 0.309017, 0, -0.951056, 10.1098, 0.55998, -30.8476 )
 
-[node name="PushableBoxV7" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV7" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.951056, 0, -0.309017, 0, 1, 0, 0.309017, 0, -0.951056, 10.1098, 3.70528, -30.8476 )
 
-[node name="PushableBoxV8" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV8" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.951056, 0, -0.309017, 0, 1, 0, 0.309017, 0, -0.951056, 10.1098, 6.85058, -30.8476 )
 
-[node name="PushableBoxV9" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV9" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.951056, 0, -0.309017, 0, 1, 0, 0.309017, 0, -0.951056, 10.1098, 9.99588, -30.8476 )
 
-[node name="PushableBoxV10" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV10" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.809017, 0, 0.587785, 0, 1, 0, -0.587785, 0, -0.809017, 11.2965, 0.08498, -28.8057 )
 
-[node name="PushableBoxV11" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV11" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.809017, 0, 0.587785, 0, 1, 0, -0.587785, 0, -0.809017, 11.2965, 3.23028, -28.8057 )
 
-[node name="PushableBoxV12" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV12" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.809017, 0, 0.587785, 0, 1, 0, -0.587785, 0, -0.809017, 11.2965, 6.37558, -28.8057 )
 
-[node name="PushableBoxV13" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV13" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.809017, 0, 0.587785, 0, 1, 0, -0.587785, 0, -0.809017, 11.2965, 9.52088, -28.8057 )
 
-[node name="PushableBoxV14" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV14" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( -0.809017, 0, 0.587785, 0, 1, 0, -0.587785, 0, -0.809017, 11.2965, 12.6662, -28.8057 )
 
 [node name="PushableBoxV15" parent="Scatter3D" instance=ExtResource( 43 )]
 transform = Transform( 0.156434, 0, 0.987688, 0, 1, 0, -0.987688, 0, 0.156434, 0.91, 0.55998, -25.8902 )
 
-[node name="PushableBoxV16" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV16" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( 0.156434, 0, 0.987688, 0, 1, 0, -0.987688, 0, 0.156434, 0.91, 3.70528, -25.8902 )
 
-[node name="PushableBoxV17" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV17" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( 0.156434, 0, 0.987688, 0, 1, 0, -0.987688, 0, 0.156434, 0.91, 6.85058, -25.8902 )
 
-[node name="PushableBoxV18" parent="Scatter3D" instance=ExtResource( 43 )]
+[node name="PushableBoxV18" parent="Scatter3D" groups=["optional"] instance=ExtResource( 43 )]
 transform = Transform( 0.156434, 0, 0.987688, 0, 1, 0, -0.987688, 0, 0.156434, 0.91, 9.99588, -25.8902 )
 
-[node name="BGMZoneV2" type="Area" parent="."]
+[node name="BGMZoneV2" type="Area" parent="." groups=["optional"]]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 0.6, -22, 2, 8.46188 )
 collision_mask = 2
 script = ExtResource( 41 )
@@ -2136,14 +2136,14 @@ fade_time = 0.2
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 27.1999, 13.8186, -47.3105 )
 shape = SubResource( 1971 )
 
-[node name="EmergencyBeaconV2" parent="." instance=ExtResource( 45 )]
+[node name="EmergencyBeaconV2" parent="." groups=["optional"] instance=ExtResource( 45 )]
 transform = Transform( -4.37114e-08, 1, 8.74228e-08, 1, 4.37114e-08, 3.82137e-15, 0, 8.74228e-08, -1, -5.95378, 8.0297, -8.15047 )
 starts_active = true
 is_interactable = false
 beacon_color = Color( 1, 0.0705882, 0, 1 )
 light_range = 10.0
 
-[node name="EmergencyBeaconV3" parent="." instance=ExtResource( 45 )]
+[node name="EmergencyBeaconV3" parent="." groups=["optional"] instance=ExtResource( 45 )]
 transform = Transform( 1.91069e-15, 4.37114e-08, -1, 1, 4.37114e-08, 3.82137e-15, 4.37114e-08, -1, -4.37114e-08, 9.04622, 8.0297, -5.95047 )
 starts_active = true
 is_interactable = false

--- a/project.godot
+++ b/project.godot
@@ -1580,6 +1580,7 @@ boot_splash/image="res://assets/splash.png"
 boot_splash/use_filter=false
 config/icon="res://assets/odisea_icon.png"
 boot_splash/minimum_display_time=3
+config/optional_nodes_enabled=true
 
 [autoload]
 
@@ -1591,6 +1592,8 @@ CinematicManager="*res://core_v2/autoloads/CinematicManager.gd"
 CameraTransition="*res://addons/camera_transition/camera_transition.tscn"
 PerformanceMonitor="*res://core_v2/autoloads/PerformanceMonitor.gd"
 SubtitlesOverlayManager="*res://core_v2/autoloads/SubtitlesOverlayManager.gd"
+OptionalNodeManager="*res://core_v2/autoloads/OptionalNodeManager.gd"
+ShaderCacheManager="*res://addons/gd-shader-cache/src/ShaderCacheManager.gd"
 
 [debug]
 
@@ -1612,7 +1615,7 @@ window/stretch/aspect="expand"
 
 [editor_plugins]
 
-enabled=PoolStringArray( "res://addons/csgtomeshinstance/plugin.cfg", "res://addons/gdUnit3/plugin.cfg", "res://addons/odisea_gizmos/plugin.cfg", "res://addons/odyssey_circuit_editor/plugin.cfg", "res://addons/qodot/plugin.cfg", "res://addons/qol-camera/plugin.cfg", "res://addons/zylann.scatter/plugin.cfg" )
+enabled=PoolStringArray( "res://addons/csgtomeshinstance/plugin.cfg", "res://addons/gd-shader-cache/plugin.cfg", "res://addons/gdUnit3/plugin.cfg", "res://addons/odisea_gizmos/plugin.cfg", "res://addons/odyssey_circuit_editor/plugin.cfg", "res://addons/qodot/plugin.cfg", "res://addons/qol-camera/plugin.cfg", "res://addons/zylann.scatter/plugin.cfg" )
 
 [gdunit3]
 
@@ -1794,6 +1797,11 @@ cursor_click_secondary={
 toggle_replay_menu={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777249,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
+toggle_optional_nodes={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777275,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 


### PR DESCRIPTION
## Summary
- Add `OptionalNodeManager` autoload to manage nodes that can be disabled on low-end platforms (Nintendo Switch, etc.)
- Mark visual/decorative nodes with the `optional` group instead of deleting them
- Add `toggle_optional_nodes` input action (F10) for in-game toggle
- Add `config/optional_nodes_enabled` project setting
- Include `ShaderCache` addon for shader pre-warming on low-end devices

## Nodes marked as optional

### BaseTerrace.tscn
- `VerticalDoor` - Decorative door
- `OcclusionArea` - Occlusion system (expensive on low-end)
- `InteriorWide` - Full interior scene with lighting
- `BGMZoneV2` - Background music zone
- `EmergencyBeaconV2/V3` - Decorative lights
- `PushableBoxV4-V5, V7-V18, V20-V24` - Extra physics objects

### Pilot_v2.tscn
- `FakeShadow` - Dynamic shadow mesh
- `OmniLight` - Player light source

## How to use

### In Editor
Set `Project Settings > Application > Config > Optional Nodes Enabled` to `false` for low-end builds.

### In Game
Press **F10** to toggle optional nodes visibility at runtime (for debugging/comparison).

### Platform Detection (future)
```gdscript
func _ready():
    if OS.get_name() == "Switch":
        OptionalNodeManager.set_optional_nodes_enabled(false)
```

## Testing
Run the game and press F10 to verify nodes appear/disappear correctly.

## Benefits over deleted nodes
- Single codebase for all platforms
- Easy A/B performance testing
- Visual debugging of scene complexity
- No merge conflicts between branches