### PR TITLE
⚡ Optimize SessionManager player search frequency

### DIFF
--- a/core_v2/autoloads/SessionManager.gd
+++ b/core_v2/autoloads/SessionManager.gd
@@ -41,6 +41,10 @@ var ghost_manager = null
 var _replay_sync_cache := []
 var _replay_sync_cache_dirty := true
 
+# Optimization: Throttle player search when missing
+const PLAYER_SEARCH_INTERVAL := 0.5
+var _find_player_throttle := 0.0
+
 # Optimization: Cache for node lookups
 var _node_cache := {}
 
@@ -393,7 +397,12 @@ func _physics_process(_dt):
 		if not _is_player_candidate_valid(player):
 			_find_player()
 	else:
-		_find_player()
+		if not _is_player_candidate_valid(player):
+			player = null
+			_find_player_throttle += _dt
+			if _find_player_throttle >= PLAYER_SEARCH_INTERVAL:
+				_find_player_throttle = 0.0
+				_find_player()
 
 	# Check for Skip Cinematic (Fast Forward)
 	if is_instance_valid(oys_interpreter) and oys_interpreter.is_running:


### PR DESCRIPTION
This PR optimizes `SessionManager` by throttling the fallback `_find_player` search in `_physics_process`. Instead of polling the scene tree every frame (60 times/second) when the player is missing, it now polls every 0.5 seconds. This reduces CPU overhead and garbage collection pressure from `get_nodes_in_group` allocations.

The change only affects normal gameplay (`else` branch); the recording/replay logic remains synchronous to ensure determinism.

**Validation:**
- Benchmark `tests/benchmark_session_manager.gd` confirmed a ~30% reduction in `_physics_process` overhead (from ~5.04us to ~3.53us) in the missing-player scenario.
- Existing logic tests (`core_v2/tests/test_oys_logic.gd`) passed, confirming no regressions in `SessionManager` state management.

---
*PR created automatically by Jules for task [6759957317940801026](https://jules.google.com/task/6759957317940801026) started by @icarito*