### PR TITLE
Add fluorescent light props

### DIFF
--- a/core_v2/props/scifi_lights/FluorescentLight.gd
+++ b/core_v2/props/scifi_lights/FluorescentLight.gd
@@ -1,0 +1,110 @@
+tool
+extends PropBaseV2
+class_name FluorescentLight
+
+# FluorescentLight.gd - A tubular fluorescent light prop with optional flickering.
+# Extends PropBaseV2 for compatibility with Logic Circuit System and interactions.
+
+export(Color) var light_color := Color(0.8, 0.9, 1.0) setget set_light_color
+export(float, 0.0, 10.0) var light_energy := 1.0 setget set_light_energy
+export(float, 0.0, 20.0) var light_range := 10.0 setget set_light_range
+export(bool) var flicker_enabled := false
+export(float, 0.1, 20.0) var flicker_speed := 10.0
+export(float, 0.0, 1.0) var flicker_intensity := 0.5
+
+var _omni_light: OmniLight = null
+var _spot_light: SpotLight = null # Optional support for spotlight too
+var _mesh: MeshInstance = null
+var _time_acc: float = 0.0
+
+func _ready():
+	._ready()
+	_omni_light = _find_child_by_type("OmniLight")
+	_spot_light = _find_child_by_type("SpotLight")
+	_mesh = _find_child_by_type("MeshInstance")
+	_apply_settings()
+
+func set_light_color(v: Color) -> void:
+	light_color = v
+	if is_inside_tree():
+		_apply_settings()
+
+func set_light_energy(v: float) -> void:
+	light_energy = v
+	if is_inside_tree():
+		_update_visuals()
+
+func set_light_range(v: float) -> void:
+	light_range = v
+	if is_inside_tree():
+		if _omni_light:
+			_omni_light.omni_range = v
+		if _spot_light:
+			_spot_light.spot_range = v
+
+func _apply_settings():
+	if _omni_light:
+		_omni_light.light_color = light_color
+		_omni_light.omni_range = light_range
+	if _spot_light:
+		_spot_light.light_color = light_color
+		_spot_light.spot_range = light_range
+
+	if _mesh and _mesh.material_override:
+		if _mesh.material_override is SpatialMaterial:
+			_mesh.material_override.emission = light_color
+		# ShaderMaterial support if needed in future
+
+	_update_visuals()
+
+func _update_visuals() -> void:
+	._update_visuals()
+
+	# anim_progress 0.0 = Off, 1.0 = On (if starts_active is true)
+	# However, InteractableBaseV2 logic:
+	# is_active = true -> target_progress = 1.0
+	# is_active = false -> target_progress = 0.0
+
+	var current_energy = light_energy * anim_progress
+
+	if flicker_enabled and anim_progress > 0.01:
+		# Deterministic flicker using _time_acc
+		# Use sine waves to create irregular looking but deterministic pattern
+		var noise = sin(_time_acc * flicker_speed) * sin(_time_acc * flicker_speed * 0.79 + 1.23)
+		# Add some high frequency noise
+		noise += 0.5 * sin(_time_acc * flicker_speed * 3.14)
+
+		# Normalize roughly to -1..1 range (it can exceed but we clamp or scale)
+		# We want flicker to reduce energy occasionally.
+		# Map noise to factor [1.0 - intensity, 1.0]
+
+		# Simple approach: if noise > threshold, dim it.
+		# Or continuous variation.
+
+		var factor = 1.0 - (flicker_intensity * 0.5 * (1.0 + noise))
+		factor = clamp(factor, 0.0, 1.2) # Allow slight over-brightness too?
+
+		current_energy *= factor
+
+	if _omni_light:
+		_omni_light.light_energy = current_energy
+	if _spot_light:
+		_spot_light.light_energy = current_energy
+
+	if _mesh and _mesh.material_override:
+		if _mesh.material_override is SpatialMaterial:
+			_mesh.material_override.emission_energy = current_energy
+
+func step(dt: float) -> void:
+	.step(dt)
+	_time_acc += dt
+	# Always update visuals if flickering is enabled and we are active,
+	# because flicker depends on time even if anim_progress is static at 1.0
+	if flicker_enabled and anim_progress > 0.01:
+		_update_visuals()
+
+func _find_child_by_type(type_name: String) -> Node:
+	for child in get_children():
+		if child.get_class() == type_name:
+			return child
+	return null

--- a/core_v2/props/scifi_lights/FluorescentLightCeiling.tscn
+++ b/core_v2/props/scifi_lights/FluorescentLightCeiling.tscn
@@ -1,0 +1,48 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://core_v2/props/scifi_lights/FluorescentLight.gd" type="Script" id=1]
+
+[sub_resource type="SpatialMaterial" id=1]
+albedo_color = Color( 0.8, 0.9, 1.0, 1 )
+roughness = 0.2
+emission_enabled = true
+emission = Color( 0.8, 0.9, 1.0, 1 )
+emission_energy = 1.0
+emission_operator = 0
+emission_on_uv2 = false
+
+[sub_resource type="CylinderMesh" id=2]
+top_radius = 0.05
+bottom_radius = 0.05
+height = 2.0
+radial_segments = 16
+rings = 1
+
+[sub_resource type="CapsuleShape" id=3]
+radius = 0.06
+height = 1.9
+
+[node name="FluorescentLightCeiling" type="StaticBody"]
+collision_layer = 4
+collision_mask = 3
+script = ExtResource( 1 )
+interaction_text = "Toggle Light"
+light_color = Color( 0.8, 0.9, 1.0, 1 )
+light_energy = 1.5
+light_range = 8.0
+
+[node name="MeshInstance" type="MeshInstance" parent="."]
+transform = Transform( -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0, 1, 0, 0, 0 )
+material_override = SubResource( 1 )
+mesh = SubResource( 2 )
+
+[node name="OmniLight" type="OmniLight" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.2, 0 )
+light_color = Color( 0.8, 0.9, 1.0, 1 )
+light_energy = 1.5
+omni_range = 8.0
+omni_attenuation = 2.0
+
+[node name="CollisionShape" type="CollisionShape" parent="."]
+transform = Transform( -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0, 1, 0, 0, 0 )
+shape = SubResource( 3 )

--- a/core_v2/props/scifi_lights/FluorescentLightFlickering.tscn
+++ b/core_v2/props/scifi_lights/FluorescentLightFlickering.tscn
@@ -1,0 +1,51 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://core_v2/props/scifi_lights/FluorescentLight.gd" type="Script" id=1]
+
+[sub_resource type="SpatialMaterial" id=1]
+albedo_color = Color( 0.7, 0.75, 0.6, 1 )
+roughness = 0.4
+emission_enabled = true
+emission = Color( 0.7, 0.75, 0.6, 1 )
+emission_energy = 0.8
+emission_operator = 0
+emission_on_uv2 = false
+
+[sub_resource type="CylinderMesh" id=2]
+top_radius = 0.05
+bottom_radius = 0.05
+height = 2.0
+radial_segments = 16
+rings = 1
+
+[sub_resource type="CapsuleShape" id=3]
+radius = 0.06
+height = 1.9
+
+[node name="FluorescentLightFlickering" type="StaticBody"]
+collision_layer = 4
+collision_mask = 3
+script = ExtResource( 1 )
+interaction_text = "Fix Light"
+light_color = Color( 0.7, 0.75, 0.6, 1 )
+light_energy = 1.0
+light_range = 8.0
+flicker_enabled = true
+flicker_speed = 15.0
+flicker_intensity = 0.8
+
+[node name="MeshInstance" type="MeshInstance" parent="."]
+transform = Transform( -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0, 1, 0, 0, 0 )
+material_override = SubResource( 1 )
+mesh = SubResource( 2 )
+
+[node name="OmniLight" type="OmniLight" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.2, 0 )
+light_color = Color( 0.7, 0.75, 0.6, 1 )
+light_energy = 1.0
+omni_range = 8.0
+omni_attenuation = 2.0
+
+[node name="CollisionShape" type="CollisionShape" parent="."]
+transform = Transform( -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0, 1, 0, 0, 0 )
+shape = SubResource( 3 )

--- a/core_v2/props/scifi_lights/FluorescentLightWall.tscn
+++ b/core_v2/props/scifi_lights/FluorescentLightWall.tscn
@@ -1,0 +1,46 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://core_v2/props/scifi_lights/FluorescentLight.gd" type="Script" id=1]
+
+[sub_resource type="SpatialMaterial" id=1]
+albedo_color = Color( 0.9, 0.95, 1.0, 1 )
+roughness = 0.2
+emission_enabled = true
+emission = Color( 0.9, 0.95, 1.0, 1 )
+emission_energy = 1.0
+emission_operator = 0
+emission_on_uv2 = false
+
+[sub_resource type="CylinderMesh" id=2]
+top_radius = 0.04
+bottom_radius = 0.04
+height = 1.0
+radial_segments = 16
+rings = 1
+
+[sub_resource type="CapsuleShape" id=3]
+radius = 0.05
+height = 0.9
+
+[node name="FluorescentLightWall" type="StaticBody"]
+collision_layer = 4
+collision_mask = 3
+script = ExtResource( 1 )
+interaction_text = "Toggle Wall Light"
+light_color = Color( 0.9, 0.95, 1.0, 1 )
+light_energy = 1.2
+light_range = 6.0
+
+[node name="MeshInstance" type="MeshInstance" parent="."]
+material_override = SubResource( 1 )
+mesh = SubResource( 2 )
+
+[node name="OmniLight" type="OmniLight" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0.2 )
+light_color = Color( 0.9, 0.95, 1.0, 1 )
+light_energy = 1.2
+omni_range = 6.0
+omni_attenuation = 2.0
+
+[node name="CollisionShape" type="CollisionShape" parent="."]
+shape = SubResource( 3 )

--- a/tests/verify_lights.gd
+++ b/tests/verify_lights.gd
@@ -1,0 +1,48 @@
+extends SceneTree
+
+func _init():
+	print("Starting light verification...")
+
+	var scenes = [
+		"res://core_v2/props/scifi_lights/FluorescentLightCeiling.tscn",
+		"res://core_v2/props/scifi_lights/FluorescentLightWall.tscn",
+		"res://core_v2/props/scifi_lights/FluorescentLightFlickering.tscn"
+	]
+
+	for scene_path in scenes:
+		print("Checking ", scene_path)
+		var packed = load(scene_path)
+		if not packed:
+			print("ERROR: Failed to load ", scene_path)
+			quit(1)
+			return
+
+		var instance = packed.instance()
+		if not instance:
+			print("ERROR: Failed to instance ", scene_path)
+			quit(1)
+			return
+
+		if not instance.get_script().resource_path.ends_with("FluorescentLight.gd"):
+			print("ERROR: Script is not FluorescentLight.gd on ", scene_path)
+			print("Found: ", instance.get_script().resource_path)
+			quit(1)
+			return
+
+		# Check properties
+		if "Flickering" in scene_path:
+			if not instance.flicker_enabled:
+				print("ERROR: FluorescentLightFlickering should have flicker_enabled=true")
+				quit(1)
+				return
+		else:
+			if instance.flicker_enabled:
+				print("ERROR: Standard lights should have flicker_enabled=false by default")
+				quit(1)
+				return
+
+		print("Verified ", scene_path)
+		instance.free()
+
+	print("All lights verified successfully.")
+	quit(0)


### PR DESCRIPTION
Implemented `FluorescentLight` props extending `PropBaseV2` compatible with the logic circuit system.
Includes a base script handling light emission and mesh material updates based on `anim_progress` and a deterministic flicker effect.
Added three variants: Ceiling, Wall, and Flickering.
Verified instantiation and properties with a headless script.

---
*PR created automatically by Jules for task [14745562764380209270](https://jules.google.com/task/14745562764380209270) started by @icarito*