### PR TITLE
Implement SwitchZone and BaseZone Logic Props

### DIFF
--- a/core_v2/props/zones/BaseZone.gd
+++ b/core_v2/props/zones/BaseZone.gd
@@ -1,0 +1,103 @@
+extends Area
+class_name BaseZone
+
+# BaseZone.gd
+# Base class for interactive zones.
+# Tracks bodies entering and exiting the area, filtering by target groups.
+
+export(Array, String) var target_groups = []
+export(bool) var require_all_groups = false
+export(bool) var active = true setget set_active
+
+signal zone_entered(body)
+signal zone_exited(body)
+signal active_changed(is_active)
+
+var _bodies_inside = []
+
+func _ready():
+	connect("body_entered", self, "_on_body_entered")
+	connect("body_exited", self, "_on_body_exited")
+
+	# Initial scan if active start
+	if active:
+		call_deferred("_initial_scan")
+
+func _initial_scan():
+	if not active: return
+	var bodies = get_overlapping_bodies()
+	for b in bodies:
+		_on_body_entered(b)
+
+func set_active(value: bool):
+	if active == value:
+		return
+
+	active = value
+	emit_signal("active_changed", active)
+
+	if active:
+		# Re-scan for bodies already inside that might have entered while inactive
+		var bodies = get_overlapping_bodies()
+		for b in bodies:
+			_on_body_entered(b)
+	else:
+		# When deactivating, we don't necessarily clear bodies,
+		# because physically they are still there.
+		# But logic relying on 'are_requirements_met' will return false.
+		pass
+
+func _on_body_entered(body: Node):
+	if not active:
+		return
+
+	if not _is_valid_body(body):
+		return
+
+	if not body in _bodies_inside:
+		_bodies_inside.append(body)
+		emit_signal("zone_entered", body)
+
+func _on_body_exited(body: Node):
+	# We remove from list regardless of active state to keep list consistent with physics
+	# BUT, we only added to list if active was true (or during scan).
+	# So if entered while inactive (not added), exit will do nothing (not in list).
+	# If entered while active (added), then deactivated, then exit:
+	# It is in list. Remove it.
+
+	if body in _bodies_inside:
+		_bodies_inside.erase(body)
+		if active:
+			emit_signal("zone_exited", body)
+
+func _is_valid_body(body: Node) -> bool:
+	if target_groups.empty():
+		return true
+
+	for group in target_groups:
+		if body.is_in_group(group):
+			return true
+
+	return false
+
+func are_requirements_met() -> bool:
+	if not active:
+		return false
+
+	if _bodies_inside.empty():
+		return false
+
+	if target_groups.empty() or not require_all_groups:
+		return true
+
+	# Check if all required groups are present
+	for group in target_groups:
+		var group_present = false
+		for body in _bodies_inside:
+			if body.is_in_group(group):
+				group_present = true
+				break
+		if not group_present:
+			return false
+
+	return true

--- a/core_v2/props/zones/SwitchZone.gd
+++ b/core_v2/props/zones/SwitchZone.gd
@@ -1,0 +1,96 @@
+extends BaseZone
+class_name SwitchZone
+
+# SwitchZone.gd
+# Logic prop that acts as a switch.
+# Can be MOMENTARY, TOGGLE, or ONE_SHOT.
+# Inherits from BaseZone for detection logic.
+
+enum SwitchMode {
+	MOMENTARY,
+	TOGGLE,
+	ONE_SHOT
+}
+
+export(SwitchMode) var switch_mode = SwitchMode.MOMENTARY
+export(bool) var is_switched_on = false setget set_is_switched_on
+
+signal switched_on()
+signal switched_off()
+signal state_changed(is_on)
+
+var _was_requirements_met_last_check = false
+
+func _ready():
+	# Register with OYS for scripting access
+	if has_node("/root/SessionManager"):
+		var sm = get_node("/root/SessionManager")
+		if sm.has_method("register_oys_actor"):
+			sm.register_oys_actor(name, self)
+
+	connect("zone_entered", self, "_on_zone_entered_internal")
+	connect("zone_exited", self, "_on_zone_exited_internal")
+	connect("active_changed", self, "_on_active_changed")
+
+	# Initial state check
+	_process_switch_logic()
+
+func _exit_tree():
+	if has_node("/root/SessionManager"):
+		var sm = get_node("/root/SessionManager")
+		if sm.has_method("unregister_oys_actor"):
+			sm.unregister_oys_actor(name)
+
+func set_is_switched_on(value: bool):
+	if is_switched_on != value:
+		is_switched_on = value
+		emit_signal("state_changed", is_switched_on)
+		if is_switched_on:
+			emit_signal("switched_on")
+		else:
+			emit_signal("switched_off")
+
+func _on_zone_entered_internal(_body):
+	_process_switch_logic()
+
+func _on_zone_exited_internal(_body):
+	_process_switch_logic()
+
+func _on_active_changed(_is_active):
+	_process_switch_logic()
+
+func _process_switch_logic():
+	var req_met = are_requirements_met()
+
+	match switch_mode:
+		SwitchMode.MOMENTARY:
+			# Direct mapping: requirements met -> ON, else -> OFF
+			if req_met and not is_switched_on:
+				self.is_switched_on = true
+			elif not req_met and is_switched_on:
+				self.is_switched_on = false
+
+		SwitchMode.TOGGLE:
+			# Edge trigger: transition from NOT met to MET
+			if req_met and not _was_requirements_met_last_check:
+				self.is_switched_on = not is_switched_on
+
+		SwitchMode.ONE_SHOT:
+			# Trigger once -> stay ON -> deactivate zone
+			if req_met and not is_switched_on:
+				self.is_switched_on = true
+				# Disable zone logic to save processing and prevent re-trigger
+				self.active = false
+
+	_was_requirements_met_last_check = req_met
+
+# OYS Helper Methods
+func get_state() -> bool:
+	return is_switched_on
+
+func set_mode(mode_str: String):
+	match mode_str.to_upper():
+		"MOMENTARY": switch_mode = SwitchMode.MOMENTARY
+		"TOGGLE": switch_mode = SwitchMode.TOGGLE
+		"ONE_SHOT": switch_mode = SwitchMode.ONE_SHOT
+	_process_switch_logic()

--- a/core_v2/props/zones/SwitchZone.tscn
+++ b/core_v2/props/zones/SwitchZone.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://core_v2/props/zones/SwitchZone.gd" type="Script" id=1]
+
+[sub_resource type="BoxShape" id=1]
+extents = Vector3( 1, 1, 1 )
+
+[sub_resource type="CubeMesh" id=2]
+size = Vector3( 2, 2, 2 )
+
+[node name="SwitchZone" type="Area"]
+script = ExtResource( 1 )
+
+[node name="CollisionShape" type="CollisionShape" parent="."]
+shape = SubResource( 1 )
+
+[node name="DebugVisuals" type="MeshInstance" parent="."]
+visible = false
+mesh = SubResource( 2 )

--- a/tests/test_switch_zone.gd
+++ b/tests/test_switch_zone.gd
@@ -1,0 +1,136 @@
+extends SceneTree
+
+func _init():
+	print("Starting SwitchZone tests...")
+
+	test_momentary()
+	test_toggle()
+	test_one_shot()
+	test_requirements()
+	test_active_flag()
+
+	print("All tests passed!")
+	quit()
+
+func test_momentary():
+	print("Testing MOMENTARY mode...")
+	var zone = load("res://core_v2/props/zones/SwitchZone.gd").new()
+	zone.switch_mode = zone.SwitchMode.MOMENTARY
+	zone.is_switched_on = false
+
+	var body = Node.new()
+	body.name = "Body1"
+
+	# Enter
+	zone._on_body_entered(body)
+	assert(zone.is_switched_on == true, "MOMENTARY: Should turn on when body enters")
+
+	# Exit
+	zone._on_body_exited(body)
+	assert(zone.is_switched_on == false, "MOMENTARY: Should turn off when body exits")
+
+	body.free()
+	zone.free()
+
+func test_toggle():
+	print("Testing TOGGLE mode...")
+	var zone = load("res://core_v2/props/zones/SwitchZone.gd").new()
+	zone.switch_mode = zone.SwitchMode.TOGGLE
+	zone.is_switched_on = false
+
+	var body = Node.new()
+
+	# Enter 1 (Toggle ON)
+	zone._on_body_entered(body)
+	assert(zone.is_switched_on == true, "TOGGLE: Should turn on first entry")
+
+	# Exit 1 (No Change)
+	zone._on_body_exited(body)
+	assert(zone.is_switched_on == true, "TOGGLE: Should not change on exit")
+
+	# Enter 2 (Toggle OFF)
+	zone._on_body_entered(body)
+	assert(zone.is_switched_on == false, "TOGGLE: Should turn off second entry")
+
+	body.free()
+	zone.free()
+
+func test_one_shot():
+	print("Testing ONE_SHOT mode...")
+	var zone = load("res://core_v2/props/zones/SwitchZone.gd").new()
+	zone.switch_mode = zone.SwitchMode.ONE_SHOT
+	zone.is_switched_on = false
+	zone.active = true
+
+	var body = Node.new()
+
+	# Enter
+	zone._on_body_entered(body)
+	assert(zone.is_switched_on == true, "ONE_SHOT: Should turn on")
+	assert(zone.active == false, "ONE_SHOT: Should deactivate zone")
+
+	# Exit (Should do nothing as inactive)
+	zone._on_body_exited(body)
+	assert(zone.is_switched_on == true, "ONE_SHOT: Should remain on")
+
+	body.free()
+	zone.free()
+
+func test_requirements():
+	print("Testing Requirements...")
+	var zone = load("res://core_v2/props/zones/SwitchZone.gd").new()
+	zone.switch_mode = zone.SwitchMode.MOMENTARY
+	zone.target_groups = ["groupA", "groupB"]
+	zone.require_all_groups = true
+
+	var bodyA = Node.new()
+	bodyA.add_to_group("groupA")
+
+	var bodyB = Node.new()
+	bodyB.add_to_group("groupB")
+
+	# Enter A only
+	zone._on_body_entered(bodyA)
+	assert(zone.is_switched_on == false, "REQ: Should stay off with only A")
+
+	# Enter B
+	zone._on_body_entered(bodyB)
+	assert(zone.is_switched_on == true, "REQ: Should turn on with A and B")
+
+	# Exit A
+	zone._on_body_exited(bodyA)
+	assert(zone.is_switched_on == false, "REQ: Should turn off when A leaves")
+
+	bodyA.free()
+	bodyB.free()
+	zone.free()
+
+func test_active_flag():
+	print("Testing Active Flag...")
+	var zone = load("res://core_v2/props/zones/SwitchZone.gd").new()
+	zone.switch_mode = zone.SwitchMode.MOMENTARY
+	zone.active = true
+
+	var body = Node.new()
+
+	# Enter
+	zone._on_body_entered(body)
+	assert(zone.is_switched_on == true, "ACTIVE: Should turn on")
+
+	# Disable
+	zone.active = false
+	# MOMENTARY logic checks 'are_requirements_met'. If !active, returns false.
+	# But _process_switch_logic needs to be called. BaseZone emits active_changed?
+	# SwitchZone connects to active_changed.
+	# But manual assignment 'zone.active = false' does NOT trigger setter if accessed directly in script unless 'self.active' or setget used properly.
+	# In GDScript, direct property access bypasses setter inside the class, but from outside (here) it uses setter if defined?
+	# Yes, 'zone.active = false' from outside uses setter.
+
+	# Setter emits active_changed -> _on_active_changed -> _process_switch_logic
+	# _process_switch_logic calls are_requirements_met -> returns false (inactive).
+	# MOMENTARY: if not req_met and is_on -> Turn OFF.
+
+	assert(zone.is_switched_on == false, "ACTIVE: Should turn off when deactivated")
+
+	body.free()
+	zone.free()


### PR DESCRIPTION
Implemented a modular spatial logic system with `BaseZone` and `SwitchZone`.
`BaseZone` handles entity detection (filtering by groups) and activation state.
`SwitchZone` implements switch logic (Momentary, Toggle, One-Shot) reacting to zone requirements.
Includes OYS registration for scripting support and deferred initialization for handling pre-placed entities.

---
*PR created automatically by Jules for task [15079523730948361646](https://jules.google.com/task/15079523730948361646) started by @icarito*