### PR TITLE
Add Holo-Planta and NeonSign helmet view props

### DIFF
--- a/assets/props/helmet_view/holo_planta/HoloPlanta.tscn
+++ b/assets/props/helmet_view/holo_planta/HoloPlanta.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://assets/props/helmet_view/holo_planta/holo_planta.gd" type="Script" id=1]
+
+[sub_resource type="QuadMesh" id=1]
+size = Vector2( 1, 2 )
+
+[sub_resource type="Shader" id=2]
+code = "shader_type spatial;
+render_mode blend_mix, depth_draw_opaque, cull_disabled, unshaded;
+
+uniform vec4 albedo : hint_color = vec4(0.0, 1.0, 0.8, 0.8);
+uniform float scanline_speed = 5.0;
+uniform float scanline_density = 20.0;
+
+void fragment() {
+	float scanline = sin(UV.y * scanline_density + TIME * scanline_speed) * 0.1 + 0.9;
+	float flicker = sin(TIME * 15.0) * 0.05 + 0.95;
+	ALBEDO = albedo.rgb * scanline * flicker;
+	ALPHA = albedo.a * (0.5 + 0.5 * scanline);
+	EMISSION = ALBEDO * 2.0;
+}
+"
+
+[sub_resource type="ShaderMaterial" id=3]
+shader = SubResource( 2 )
+shader_param/albedo = Color( 0, 1, 0.8, 0.8 )
+shader_param/scanline_speed = 5.0
+shader_param/scanline_density = 20.0
+
+[sub_resource type="SpatialMaterial" id=4]
+flags_transparent = true
+flags_unshaded = true
+albedo_color = Color( 0, 1, 0.8, 0.8 )
+
+[sub_resource type="QuadMesh" id=5]
+size = Vector2( 0.05, 0.05 )
+
+[node name="HoloPlanta" type="Spatial"]
+script = ExtResource( 1 )
+
+[node name="HoloMesh" type="MeshInstance" parent="."]
+mesh = SubResource( 1 )
+material/0 = SubResource( 3 )
+
+[node name="HoloParticles" type="CPUParticles" parent="."]
+material_override = SubResource( 4 )
+amount = 16
+lifetime = 2.0
+mesh = SubResource( 5 )
+emission_shape = 2
+emission_box_extents = Vector3( 0.5, 0.1, 0.5 )
+direction = Vector3( 0, 1, 0 )
+gravity = Vector3( 0, 0.5, 0 )
+initial_velocity = 1.0

--- a/assets/props/helmet_view/holo_planta/holo_planta.gd
+++ b/assets/props/helmet_view/holo_planta/holo_planta.gd
@@ -1,0 +1,8 @@
+tool
+extends "res://core_v2/props/PropBaseV2.gd"
+
+func _ready():
+    pass
+
+func _update_visuals(progress: float):
+    pass

--- a/assets/props/helmet_view/neon_sign/NeonSign.tscn
+++ b/assets/props/helmet_view/neon_sign/NeonSign.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://assets/props/helmet_view/neon_sign/neon_sign.gd" type="Script" id=1]
+
+[sub_resource type="CylinderMesh" id=1]
+top_radius = 0.1
+bottom_radius = 0.1
+height = 2.0
+
+[sub_resource type="SpatialMaterial" id=2]
+albedo_color = Color( 0.1, 0.1, 0.1, 1 )
+emission_enabled = true
+emission = Color( 1, 0, 1, 1 )
+emission_energy = 3.0
+emission_operator = 0
+emission_on_uv2 = false
+
+[node name="NeonSign" type="Spatial"]
+script = ExtResource( 1 )
+
+[node name="NeonTube" type="MeshInstance" parent="."]
+mesh = SubResource( 1 )
+material/0 = SubResource( 2 )
+
+[node name="NeonLight" type="OmniLight" parent="."]
+light_color = Color( 1, 0, 1, 1 )
+light_energy = 2.0
+omni_range = 5.0

--- a/assets/props/helmet_view/neon_sign/neon_sign.gd
+++ b/assets/props/helmet_view/neon_sign/neon_sign.gd
@@ -1,0 +1,17 @@
+tool
+extends "res://core_v2/props/PropBaseV2.gd"
+
+func _ready():
+    pass
+
+func _update_visuals(progress: float):
+    if has_node("NeonLight"):
+        var light = $NeonLight
+        light.light_energy = 2.0 * progress
+
+    if has_node("NeonTube"):
+        var mat = $NeonTube.get_surface_material(0)
+        if mat and mat is SpatialMaterial:
+            mat = mat.duplicate()
+            mat.emission_energy = 3.0 * progress
+            $NeonTube.set_surface_material(0, mat)


### PR DESCRIPTION
Add Holo-Planta and NeonSign props with shaders and emissive materials

- Creates `HoloPlanta.tscn` using a custom transparent shader with scanlines, flicker, and a CPUParticle system for "spores".
- Creates `NeonSign.tscn` using a mesh with emissive material and an OmniLight to illuminate surroundings.
- Validated using standard `./test_prop.sh` script to verify visual difference via pixel threshold.

---
*PR created automatically by Jules for task [576850916560058774](https://jules.google.com/task/576850916560058774) started by @icarito*