### PR TITLE
Add Helmet View Props

### DIFF
--- a/core_v2/props/helmet_view/drone_dock/DroneDock.gd
+++ b/core_v2/props/helmet_view/drone_dock/DroneDock.gd
@@ -1,0 +1,18 @@
+tool
+extends PropBaseV2
+class_name DroneDock
+
+var mat: Material
+
+func _ready():
+    ._ready()
+    var mesh_inst = get_node_or_null("Mesh")
+    if mesh_inst and mesh_inst.mesh and mesh_inst.mesh.get_surface_count() > 0:
+        var m = mesh_inst.mesh.surface_get_material(0)
+        if m:
+            mat = m.duplicate()
+            mesh_inst.mesh.surface_set_material(0, mat)
+
+func _update_visuals():
+    if mat and mat is SpatialMaterial:
+        mat.emission_energy = 0.0 + anim_progress * 5.0

--- a/core_v2/props/helmet_view/drone_dock/DroneDock.tscn
+++ b/core_v2/props/helmet_view/drone_dock/DroneDock.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://core_v2/props/helmet_view/drone_dock/DroneDock.gd" type="Script" id=1]
+
+[sub_resource type="SpatialMaterial" id=1]
+emission_enabled = true
+emission = Color( 0, 0, 1, 1 )
+emission_energy = 1.0
+emission_operator = 0
+emission_on_uv2 = false
+
+[sub_resource type="CylinderMesh" id=2]
+material = SubResource( 1 )
+height = 0.5
+
+[node name="DroneDock" type="Spatial"]
+script = ExtResource( 1 )
+interaction_text = "Interact"
+anim_duration = 1.0
+starts_active = false
+auto_interact = false
+one_off = false
+is_interactable = true
+manual_toggle = true
+debug = false
+linked_switch_path = NodePath("")
+linked_switch_paths = [  ]
+visual_parts_paths = [  ]
+debug_draw = false
+
+[node name="Mesh" type="MeshInstance" parent="."]
+mesh = SubResource( 2 )

--- a/core_v2/props/helmet_view/fusion_core/FusionCore.gd
+++ b/core_v2/props/helmet_view/fusion_core/FusionCore.gd
@@ -1,0 +1,18 @@
+tool
+extends PropBaseV2
+class_name FusionCore
+
+var mat: Material
+
+func _ready():
+    ._ready()
+    var mesh_inst = get_node_or_null("Mesh")
+    if mesh_inst and mesh_inst.mesh and mesh_inst.mesh.get_surface_count() > 0:
+        var m = mesh_inst.mesh.surface_get_material(0)
+        if m:
+            mat = m.duplicate()
+            mesh_inst.mesh.surface_set_material(0, mat)
+
+func _update_visuals():
+    if mat and mat is ShaderMaterial:
+        mat.set_shader_param("charge_level", anim_progress)

--- a/core_v2/props/helmet_view/fusion_core/FusionCore.tscn
+++ b/core_v2/props/helmet_view/fusion_core/FusionCore.tscn
@@ -1,0 +1,53 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://core_v2/props/helmet_view/fusion_core/FusionCore.gd" type="Script" id=1]
+
+[sub_resource type="Shader" id=3]
+code = "
+shader_type spatial;
+render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlick_ggx;
+uniform vec4 color_full : hint_color = vec4(0.0, 1.0, 1.0, 1.0);
+uniform vec4 color_empty : hint_color = vec4(0.3, 0.0, 0.0, 1.0);
+uniform float charge_level = 1.0;
+uniform float pulse_freq = 2.0;
+
+void fragment() {
+    vec4 current_color = mix(color_empty, color_full, charge_level);
+    float pulse = (sin(TIME * pulse_freq) * 0.5 + 0.5) * charge_level;
+    ALBEDO = current_color.rgb;
+    EMISSION = current_color.rgb * (1.0 + pulse);
+    NORMALMAP = vec3(0.5, 0.5, 1.0);
+}
+"
+
+[sub_resource type="ShaderMaterial" id=4]
+shader = SubResource( 3 )
+shader_param/color_full = Color( 0, 1, 1, 1 )
+shader_param/color_empty = Color( 0.3, 0, 0, 1 )
+shader_param/charge_level = 1.0
+shader_param/pulse_freq = 2.0
+
+[sub_resource type="CylinderMesh" id=2]
+material = SubResource( 4 )
+top_radius = 0.3
+bottom_radius = 0.3
+height = 1.0
+radial_segments = 8
+
+[node name="FusionCore" type="Spatial"]
+script = ExtResource( 1 )
+interaction_text = "Interact"
+anim_duration = 1.0
+starts_active = false
+auto_interact = false
+one_off = false
+is_interactable = true
+manual_toggle = true
+debug = false
+linked_switch_path = NodePath("")
+linked_switch_paths = [  ]
+visual_parts_paths = [  ]
+debug_draw = false
+
+[node name="Mesh" type="MeshInstance" parent="."]
+mesh = SubResource( 2 )

--- a/core_v2/props/helmet_view/gravity_anchor/GravityAnchor.gd
+++ b/core_v2/props/helmet_view/gravity_anchor/GravityAnchor.gd
@@ -1,0 +1,18 @@
+tool
+extends PropBaseV2
+class_name GravityAnchor
+
+var mat: Material
+
+func _ready():
+    ._ready()
+    var mesh_inst = get_node_or_null("Mesh")
+    if mesh_inst and mesh_inst.mesh and mesh_inst.mesh.get_surface_count() > 0:
+        var m = mesh_inst.mesh.surface_get_material(0)
+        if m:
+            mat = m.duplicate()
+            mesh_inst.mesh.surface_set_material(0, mat)
+
+func _update_visuals():
+    if mat and mat is ShaderMaterial:
+        mat.set_shader_param("stability", anim_progress)

--- a/core_v2/props/helmet_view/gravity_anchor/GravityAnchor.tscn
+++ b/core_v2/props/helmet_view/gravity_anchor/GravityAnchor.tscn
@@ -1,0 +1,50 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://core_v2/props/helmet_view/gravity_anchor/GravityAnchor.gd" type="Script" id=1]
+
+[sub_resource type="Shader" id=3]
+code = "
+shader_type spatial;
+render_mode blend_mix,depth_draw_opaque,cull_back,diffuse_burley,specular_schlick_ggx,unshaded;
+uniform vec4 color_stable : hint_color = vec4(0.0, 1.0, 1.0, 1.0);
+uniform vec4 color_unstable : hint_color = vec4(1.0, 0.5, 0.0, 1.0);
+uniform float stability = 1.0; // 1.0 stable, 0.0 unstable
+
+void fragment() {
+    vec4 current_color = mix(color_unstable, color_stable, stability);
+    float flicker = mix(step(0.5, fract(TIME * 10.0)), 1.0, stability);
+    ALBEDO = current_color.rgb;
+    ALPHA = flicker;
+}
+"
+
+[sub_resource type="ShaderMaterial" id=4]
+shader = SubResource( 3 )
+shader_param/color_stable = Color( 0, 1, 1, 1 )
+shader_param/color_unstable = Color( 1, 0.5, 0, 1 )
+shader_param/stability = 1.0
+
+[sub_resource type="CylinderMesh" id=2]
+material = SubResource( 4 )
+top_radius = 0.001
+bottom_radius = 0.5
+height = 1.0
+radial_segments = 4
+
+[node name="GravityAnchor" type="Spatial"]
+script = ExtResource( 1 )
+interaction_text = "Interact"
+anim_duration = 1.0
+starts_active = false
+auto_interact = false
+one_off = false
+is_interactable = true
+manual_toggle = true
+debug = false
+linked_switch_path = NodePath("")
+linked_switch_paths = [  ]
+visual_parts_paths = [  ]
+debug_draw = false
+
+[node name="Mesh" type="MeshInstance" parent="."]
+mesh = SubResource( 2 )

--- a/core_v2/props/helmet_view/grip_point/GripPoint.gd
+++ b/core_v2/props/helmet_view/grip_point/GripPoint.gd
@@ -1,0 +1,20 @@
+tool
+extends PropBaseV2
+class_name GripPoint
+
+var mat: Material
+
+func _ready():
+    ._ready()
+    var mesh_inst = get_node_or_null("Mesh")
+    if mesh_inst and mesh_inst.mesh and mesh_inst.mesh.get_surface_count() > 0:
+        var m = mesh_inst.mesh.surface_get_material(0)
+        if m:
+            mat = m.duplicate()
+            mesh_inst.mesh.surface_set_material(0, mat)
+
+func _update_visuals():
+    if mat and mat is SpatialMaterial:
+        mat.emission_enabled = true
+        mat.emission = Color(1.0, 0.0, 0.0) * anim_progress
+        mat.emission_energy = anim_progress * 5.0

--- a/core_v2/props/helmet_view/grip_point/GripPoint.tscn
+++ b/core_v2/props/helmet_view/grip_point/GripPoint.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://core_v2/props/helmet_view/grip_point/GripPoint.gd" type="Script" id=1]
+
+[sub_resource type="SpatialMaterial" id=1]
+metallic = 1.0
+roughness = 0.2
+
+[sub_resource type="CubeMesh" id=2]
+material = SubResource( 1 )
+size = Vector3( 0.1, 1, 0.1 )
+
+[node name="GripPoint" type="Spatial"]
+script = ExtResource( 1 )
+interaction_text = "Interact"
+anim_duration = 1.0
+starts_active = false
+auto_interact = false
+one_off = false
+is_interactable = true
+manual_toggle = true
+debug = false
+linked_switch_path = NodePath("")
+linked_switch_paths = [  ]
+visual_parts_paths = [  ]
+debug_draw = false
+
+[node name="Mesh" type="MeshInstance" parent="."]
+mesh = SubResource( 2 )

--- a/core_v2/props/helmet_view/hazard_tape/HazardTape.gd
+++ b/core_v2/props/helmet_view/hazard_tape/HazardTape.gd
@@ -1,0 +1,18 @@
+tool
+extends PropBaseV2
+class_name HazardTape
+
+var mat: Material
+
+func _ready():
+    ._ready()
+    var mesh_inst = get_node_or_null("Mesh")
+    if mesh_inst and mesh_inst.mesh and mesh_inst.mesh.get_surface_count() > 0:
+        var m = mesh_inst.mesh.surface_get_material(0)
+        if m:
+            mat = m.duplicate()
+            mesh_inst.mesh.surface_set_material(0, mat)
+
+func _update_visuals():
+    if mat and mat is ShaderMaterial:
+        mat.set_shader_param("scroll_speed", 1.0 + anim_progress * 5.0)

--- a/core_v2/props/helmet_view/hazard_tape/HazardTape.tscn
+++ b/core_v2/props/helmet_view/hazard_tape/HazardTape.tscn
@@ -1,0 +1,48 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://core_v2/props/helmet_view/hazard_tape/HazardTape.gd" type="Script" id=1]
+
+[sub_resource type="Shader" id=3]
+code = "
+shader_type spatial;
+render_mode blend_mix,depth_draw_opaque,cull_disabled,diffuse_burley,specular_schlick_ggx,unshaded;
+uniform vec4 color1 : hint_color = vec4(1.0, 0.5, 0.0, 1.0);
+uniform vec4 color2 : hint_color = vec4(1.0, 0.0, 0.0, 1.0);
+uniform float scroll_speed = 1.0;
+
+void fragment() {
+    float stripe = step(0.5, fract((UV.x + UV.y + TIME * scroll_speed) * 5.0));
+    vec4 c = mix(color1, color2, stripe);
+    float glitch = step(0.95, fract(sin(dot(UV.yy, vec2(12.9898, 78.233))) * 43758.5453 + TIME * 10.0));
+    ALBEDO = c.rgb;
+    ALPHA = mix(1.0, 0.0, glitch);
+}
+"
+
+[sub_resource type="ShaderMaterial" id=4]
+shader = SubResource( 3 )
+shader_param/color1 = Color( 1, 0.5, 0, 1 )
+shader_param/color2 = Color( 1, 0, 0, 1 )
+shader_param/scroll_speed = 1.0
+
+[sub_resource type="QuadMesh" id=2]
+material = SubResource( 4 )
+size = Vector2( 5, 1 )
+
+[node name="HazardTape" type="Spatial"]
+script = ExtResource( 1 )
+interaction_text = "Interact"
+anim_duration = 1.0
+starts_active = false
+auto_interact = false
+one_off = false
+is_interactable = true
+manual_toggle = true
+debug = false
+linked_switch_path = NodePath("")
+linked_switch_paths = [  ]
+visual_parts_paths = [  ]
+debug_draw = false
+
+[node name="Mesh" type="MeshInstance" parent="."]
+mesh = SubResource( 2 )


### PR DESCRIPTION
Created `FusionCore`, `HazardTape`, `DroneDock`, `GravityAnchor`, and `GripPoint` interactive helmet-view props with dynamic materials. All generated files have been formatted to use the Godot project standard, inheriting from `PropBaseV2` and properly overwriting `_update_visuals` with visual alterations.

---
*PR created automatically by Jules for task [7498980396712515860](https://jules.google.com/task/7498980396712515860) started by @icarito*