### PR TITLE
Implement SCS Pedestrian Tubes (Phase 1)

### DIFF
--- a/core_v2/props/tube/TubeAirlock.gd
+++ b/core_v2/props/tube/TubeAirlock.gd
@@ -1,0 +1,42 @@
+extends Area
+
+# TubeAirlock.gd - Automatic airlock for pedestrian tubes
+# Detects player and triggers scene transition to another dome/spawn point.
+
+export(String) var target_dome := ""
+export(String) var target_spawn := ""
+export(bool) var auto_open := true
+
+func _ready() -> void:
+	if not is_connected("body_entered", self, "_on_body_entered"):
+		connect("body_entered", self, "_on_body_entered")
+
+func _on_body_entered(body: Node) -> void:
+	if not body.is_in_group("player"):
+		return
+
+	if target_dome != "":
+		_transition_to_target()
+
+func _transition_to_target() -> void:
+	var sm = get_node_or_null("/root/SceneManager")
+	if sm:
+		var params = {
+			"target_spawn_id": target_spawn,
+			"fade_out": 0.5,
+			"fade_in": 0.5,
+			"wait_for_fade_out": true
+		}
+		sm.goto_scene(target_dome, params)
+	else:
+		printerr("[TubeAirlock] SceneManager not found")
+
+func open_doors() -> void:
+	var door = get_node_or_null("IrisDoorV2")
+	if door and door.has_method("set_active"):
+		door.set_active(true)
+
+func close_doors() -> void:
+	var door = get_node_or_null("IrisDoorV2")
+	if door and door.has_method("set_active"):
+		door.set_active(false)

--- a/core_v2/props/tube/TubeAirlock.tscn
+++ b/core_v2/props/tube/TubeAirlock.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://core_v2/props/tube/TubeAirlock.gd" type="Script" id=1]
+[ext_resource path="res://core_v2/props/IrisDoorV2.tscn" type="PackedScene" id=2]
+
+[sub_resource type="BoxShape" id=1]
+extents = Vector3( 2, 2, 1 )
+
+[sub_resource type="SpatialMaterial" id=2]
+albedo_color = Color( 0.3, 0.3, 0.3, 1 )
+metallic = 0.8
+roughness = 0.2
+
+[node name="TubeAirlock" type="Area"]
+collision_layer = 0
+collision_mask = 2
+script = ExtResource( 1 )
+
+[node name="CollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1 )
+shape = SubResource( 1 )
+
+[node name="IrisDoorV2" parent="." instance=ExtResource( 2 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )
+
+[node name="FrameExtension" type="CSGCombiner" parent="."]
+
+[node name="Outer" type="CSGCylinder" parent="FrameExtension"]
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 1 )
+radius = 3.6
+height = 2.0
+sides = 24
+material = SubResource( 2 )
+
+[node name="Inner" type="CSGCylinder" parent="FrameExtension/Outer"]
+operation = 2
+radius = 2.5
+height = 2.1
+sides = 24
+material = SubResource( 2 )

--- a/core_v2/props/tube/TubeRing.tscn
+++ b/core_v2/props/tube/TubeRing.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=3 format=2]
+
+[sub_resource type="SpatialMaterial" id=1]
+albedo_color = Color( 0.2, 0.2, 0.2, 1 )
+metallic = 1.0
+roughness = 0.2
+
+[sub_resource type="CylinderMesh" id=2]
+material = SubResource( 1 )
+top_radius = 2.7
+bottom_radius = 2.7
+height = 0.15
+rings = 1
+sections = 32
+
+[node name="TubeRing" type="Spatial"]
+
+[node name="MeshInstance" type="MeshInstance" parent="."]
+mesh = SubResource( 2 )
+material/0 = null

--- a/core_v2/props/tube/TubeSection.tscn
+++ b/core_v2/props/tube/TubeSection.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=3 format=2]
+
+[sub_resource type="SpatialMaterial" id=1]
+flags_transparent = true
+params_cull_mode = 2
+albedo_color = Color( 0.7, 0.8, 1, 0.3 )
+metallic = 0.1
+roughness = 0.05
+
+[sub_resource type="CylinderMesh" id=2]
+material = SubResource( 1 )
+top_radius = 2.5
+bottom_radius = 2.5
+height = 10.0
+rings = 1
+sections = 32
+
+[node name="TubeSection" type="Spatial"]
+
+[node name="MeshInstance" type="MeshInstance" parent="."]
+mesh = SubResource( 2 )
+material/0 = null

--- a/core_v2/props/tube/TubeZeroGravityZone.tscn
+++ b/core_v2/props/tube/TubeZeroGravityZone.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://core_v2/props/ZeroGravityZone.gd" type="Script" id=1]
+
+[sub_resource type="CylinderShape" id=1]
+radius = 2.5
+height = 10.0
+
+[node name="TubeZeroGravityZone" type="Area"]
+collision_layer = 0
+collision_mask = 2
+script = ExtResource( 1 )
+
+[node name="CollisionShape" type="CollisionShape" parent="."]
+shape = SubResource( 1 )

--- a/core_v2/tests/test_tube_airlock.oys
+++ b/core_v2/tests/test_tube_airlock.oys
@@ -1,0 +1,28 @@
+LEVEL res://core_v2/tests/test_tube_airlock.tscn
+
+SECTION "Tube Airlock Transition Test"
+    // The player starts at "start" (0, 0.5, 0)
+    // AirlockStart is at (0, 2, -5)
+
+    // 1. Move player to the airlock entrance
+    SET_POS "Pilot" [0, 0.5, -4]
+    WAIT 0.5
+
+    // 2. Trigger the airlock by moving inside its Area
+    // The Area CollisionShape is at (0, 0, 1) relative to its parent (0, 2, -5)
+    // So global collision is at (0, 2, -4)
+    SET_POS "Pilot" [0, 2, -4]
+    WAIT 1.0
+
+    // 3. Since the target_dome is the same scene but different spawn point,
+    // we should eventually end up at SpawnPointEnd (0, 2, -17)
+
+    SET $pilot_z GET_NODE_POS_Z "Pilot"
+
+    // Check if we reached the end spawn point
+    ASSERT $pilot_z < -16.0 "Player should have transitioned to SpawnPointEnd (Z < -16)"
+    ASSERT $pilot_z > -18.0 "Player should have transitioned to SpawnPointEnd (Z > -18)"
+
+    SCREENSHOT "transition_complete"
+
+END

--- a/core_v2/tests/test_tube_airlock.tscn
+++ b/core_v2/tests/test_tube_airlock.tscn
@@ -1,0 +1,62 @@
+[gd_scene load_steps=8 format=2]
+
+[ext_resource path="res://core_v2/actors/Pilot_v2.tscn" type="PackedScene" id=1]
+[ext_resource path="res://core_v2/props/tube/TubeSection.tscn" type="PackedScene" id=2]
+[ext_resource path="res://core_v2/props/tube/TubeAirlock.tscn" type="PackedScene" id=3]
+[ext_resource path="res://core_v2/props/tube/TubeRing.tscn" type="PackedScene" id=4]
+[ext_resource path="res://core_v2/props/tube/TubeZeroGravityZone.tscn" type="PackedScene" id=5]
+[ext_resource path="res://core_v2/components/SpawnPointV2.gd" type="Script" id=6]
+
+[sub_resource type="CubeMesh" id=1]
+size = Vector3( 20, 1, 20 )
+
+[node name="TestTubeAirlock" type="Spatial"]
+
+[node name="Floor" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.5, 0 )
+mesh = SubResource( 1 )
+material/0 = null
+
+[node name="StaticBody" type="StaticBody" parent="Floor"]
+
+[node name="CollisionShape" type="CollisionShape" parent="Floor/StaticBody"]
+
+[node name="SpawnPoint" type="Position3D" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0 )
+script = ExtResource( 6 )
+spawn_id = "start"
+
+[node name="Pilot" parent="." instance=ExtResource( 1 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0 )
+
+[node name="Tube" type="Spatial" parent="."]
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 2, -10 )
+
+[node name="TubeSection" parent="Tube" instance=ExtResource( 2 )]
+
+[node name="TubeRing" parent="Tube" instance=ExtResource( 4 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5, 0 )
+
+[node name="TubeRing2" parent="Tube" instance=ExtResource( 4 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -5, 0 )
+
+[node name="TubeZeroGravityZone" parent="Tube" instance=ExtResource( 5 )]
+
+[node name="AirlockStart" parent="." instance=ExtResource( 3 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, -5 )
+target_dome = "res://core_v2/tests/test_tube_airlock.tscn"
+target_spawn = "end"
+
+[node name="AirlockEnd" parent="." instance=ExtResource( 3 )]
+transform = Transform( -1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 2, -15 )
+target_dome = "res://core_v2/tests/test_tube_airlock.tscn"
+target_spawn = "start"
+
+[node name="SpawnPointEnd" type="Position3D" parent="."]
+transform = Transform( -1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 2, -17 )
+script = ExtResource( 6 )
+spawn_id = "end"
+
+[node name="DirectionalLight" type="DirectionalLight" parent="."]
+transform = Transform( 0.866025, -0.25, 0.433013, 0, 0.866025, 0.5, -0.5, -0.433013, 0.75, 0, 10, 0 )
+shadow_enabled = true


### PR DESCRIPTION
This change implements the first phase of the SCS Transportation System, focusing on pedestrian tubes. It includes transparent glass tube sections, metallic support rings, automatic airlocks for dome-to-dome transitions via the SceneManager, and zero-gravity zone components. A comprehensive test scene with OYS validation script is also provided.

---
*PR created automatically by Jules for task [587620666302979125](https://jules.google.com/task/587620666302979125) started by @icarito*