### PR TITLE
perf: WorldRotator optimizations — sky sync throttle + continuous tracking SLERP + LOD SCAD

### DIFF
--- a/core_v2/levels/OdiseaExterior.gd
+++ b/core_v2/levels/OdiseaExterior.gd
@@ -62,7 +62,7 @@ func _resolve_player_camera() -> Camera:
 
 func _process(_delta: float) -> void:
 	_sync_selection_from_rotator()
-	_tick_dome_facade_cursor()  # sigue la animación/rotación del WorldRotator cada frame
+	# _tick_dome_facade_cursor ahora es no-op (FD-041 usa LOD), se mantiene por compatibilidad.
 	_reset_camera_roll()
 
 func _resolve_spawn_state() -> void:
@@ -709,7 +709,8 @@ func _configure_gravity_for_selected_plate(plate_canonical: Transform) -> void:
 func _reset_camera_roll() -> void:
 	if not _camera:
 		return
-	_camera.rotation.z = 0.0
+	if _camera.rotation.z != 0.0:
+		_camera.rotation.z = 0.0
 
 # --- DomeFacade Cursor ---
 # Pre-instancia una DomeFacade por tipo de escena y la reposiciona al plate activo.

--- a/core_v2/systems/WorldRotator.gd
+++ b/core_v2/systems/WorldRotator.gd
@@ -108,6 +108,9 @@ var _pool_update_counter: int = 0
 var _spiral_extents_cache: Dictionary = {}  # spiral_index (int) -> Vector3
 var _target_plate_query_counter: int = 0
 var _world_environment_sky_entries: Array = []
+var _sky_frame_sync_counter: int = 0
+var _sky_frame_sync_interval: int = 6  # solo sincronizar cada N frames físicos
+var _last_sky_basis := Basis.IDENTITY  # cache para evitar recomputar sin cambios
 # Retrocompatibilidad: alias del pool para tests que lean _generated_collision_bodies
 var _generated_collision_bodies: Array setget ,_get_generated_collision_bodies
 func _get_generated_collision_bodies() -> Array:
@@ -199,7 +202,10 @@ func _physics_process(delta: float) -> void:
 	if pool_update_due:
 		_pool_update_counter = 0
 		_assign_pool_to_nearest_plates()
-	_sync_world_environment_sky_frames()
+	_sky_frame_sync_counter += 1
+	if _sky_frame_sync_counter >= _sky_frame_sync_interval:
+		_sky_frame_sync_counter = 0
+		_sync_world_environment_sky_frames()
 
 # ── API pública ──────────────────────────────────────────────────────────────
 
@@ -611,12 +617,17 @@ func _collect_world_environment_sky_frames(root: Node) -> void:
 		_collect_world_environment_sky_frames(child)
 
 func _sync_world_environment_sky_frames() -> void:
+	# Evitar recomputar si la orientación no cambió desde la última sincronización.
+	var current_basis: Basis = global_transform.basis
+	if current_basis.is_equal_approx(_last_sky_basis):
+		return
+	_last_sky_basis = current_basis
 	for entry in _world_environment_sky_entries:
 		var world_environment: WorldEnvironment = entry.get("world_environment", null)
 		var environment: Environment = entry.get("environment", null)
 		if not is_instance_valid(world_environment) or environment == null:
 			continue
-		environment.background_sky_orientation = global_transform.basis * entry.get("authored_orientation", Basis.IDENTITY)
+		environment.background_sky_orientation = current_basis * entry.get("authored_orientation", Basis.IDENTITY)
 
 func _sync_spirals() -> void:
 	_sync_spirals_recursive(self)
@@ -751,9 +762,15 @@ func _update_continuous_tracking(_delta: float) -> bool:
 
 	_target_global_transform = Transform(new_basis, new_origin)
 	_has_transform_target = true
-	# En continuous tracking el rotator es parte del frame de referencia del piloto.
-	# Si queda atrasado por slerp, los slots y rigid bodies reciben transforms viejos.
-	global_transform = _target_global_transform
+	# Interpolar suavemente hacia el target para evitar saltos de cámara.
+	var t: float = min(1.0, _get_effective_rotation_speed() * _delta * 6.0)
+	var eased_t: float = t * t * (3.0 - 2.0 * t)
+	var current: Transform = global_transform
+	var q_cur: Quat = current.basis.get_rotation_quat()
+	var q_target: Quat = _target_global_transform.basis.get_rotation_quat()
+	var q_new: Quat = q_cur.slerp(q_target, eased_t)
+	var origin_new: Vector3 = current.origin.linear_interpolate(_target_global_transform.origin, eased_t)
+	global_transform = Transform(Basis(q_new).orthonormalized(), origin_new)
 	return true
 
 func _get_tracking_target() -> Spatial:

--- a/models/odisea_lod.scad
+++ b/models/odisea_lod.scad
@@ -1,0 +1,164 @@
+//////////////////////////////////////////
+// ODISEA — MESH LOD COMBINADO
+//////////////////////////////////////////
+// LOD unificado para reemplazar cientos de MultiMesh plates.
+// 
+// Estructura:
+//   - 4 espirales (0°, 90°, 180°, 270°) 
+//   - Núcleo central con domo
+//   - Domos en las posiciones del DomeRegistry
+//
+// Uso: abrir en OpenSCAD, elegir $fn para nivel de detalle.
+//   $fn=12 → LOD0 (muy lejos, ~1-2K tris)
+//   $fn=24 → LOD1 (medio, ~8-10K tris)
+//   Exportar como STL y convertir a .glb para Godot.
+
+// -------- DETALLE --------
+$fn = 16; // 12=ultra low, 16=low, 24=medium
+
+// -------- PARÁMETROS (matchean TerraceSpiral.gd + platforms.scad) --------
+r_spiral = 200;         // radio del eje a las plates
+height_total = 8000;    // altura total de la espiral
+turns = 8;              // vueltas de cada espiral
+plate_step = 40;        // distancia entre plates
+plate_count = 200;      // plates por espiral
+plate_size = 80;        // ancho de cada plate
+plate_thickness = 2;    // grosor de plate
+
+// Offsets angulares de las 4 espirales
+spiral_offsets = [0, 90, 180, 270];
+
+// -------- DOMO CENTRAL --------
+dome_radius = 120;
+dome_height = 4000;
+
+// -------- DOMOS (posiciones del DomeRegistry) --------
+// Formato: [spiral_index, plate_index]
+domes = [
+    [0, 1],   // dome_02 - Bahía de Ingeniería
+    [0, 15],  // dome_01 - Laboratorio Biológico
+    [2, 5],   // dome_03 - Criogenia
+];
+
+// -------- FUNCIONES --------
+function lerp(a, b, t) = a + (b - a) * t;
+
+// Posición de una plate en una espiral
+function plate_angle(spiral_offset, plate_index) = 
+    spiral_offset + plate_index * 360 * turns / plate_count;
+
+function plate_z(plate_index) = 
+    plate_index * plate_step;
+
+function plate_xyz(spiral_offset, plate_index) = [
+    r_spiral * cos(plate_angle(spiral_offset, plate_index)),
+    r_spiral * sin(plate_angle(spiral_offset, plate_index)),
+    plate_z(plate_index)
+];
+
+// -------- MÓDULOS --------
+
+// Placa individual (plana, rectangular)
+module single_plate(spiral_offset, plate_index) {
+    pos = plate_xyz(spiral_offset, plate_index);
+    ang = plate_angle(spiral_offset, plate_index);
+    
+    translate([pos[0], pos[1], pos[2]])
+        rotate([0, 0, ang])
+            rotate([0, -90, 0])  // centrífugo: cara interior hacia +Z
+                translate([plate_size/2, 0, 0])
+                    cube([plate_size, plate_size, plate_thickness], center=true);
+}
+
+// Espiral completa (todas las plates)
+module spiral_path(spiral_offset) {
+    for (i = [0 : 2 : plate_count - 1]) {  // cada 2da plate para LOD
+        single_plate(spiral_offset, i);
+    }
+}
+
+// Cilindro/rampa simplificada (versión ultra-LOD: un solo tubo helicoidal)
+module spiral_ramp(spiral_offset, height_start, height_end) {
+    steps = 40;
+    step_h = (height_end - height_start) / steps;
+    
+    for (i = [0 : steps - 1]) {
+        z0 = height_start + i * step_h;
+        z1 = z0 + step_h;
+        plate0 = floor(z0 / plate_step);
+        plate1 = floor(z1 / plate_step);
+        
+        pos0 = plate_xyz(spiral_offset, plate0);
+        pos1 = plate_xyz(spiral_offset, plate1);
+        
+        // Tubo entre plates consecutivas
+        hull() {
+            translate(pos0)
+                rotate([0, 0, plate_angle(spiral_offset, plate0)])
+                    rotate([0, -90, 0])
+                        translate([plate_size/2, 0, 0])
+                            cube([plate_size, plate_size, plate_thickness], center=true);
+            translate(pos1)
+                rotate([0, 0, plate_angle(spiral_offset, plate1)])
+                    rotate([0, -90, 0])
+                        translate([plate_size/2, 0, 0])
+                            cube([plate_size, plate_size, plate_thickness], center=true);
+        }
+    }
+}
+
+// Domo individual (esfera achatada)
+module dome_bump(pos) {
+    translate(pos)
+        translate([0, 0, 30])  // elevado sobre la plate
+            scale([1, 1, 0.5])
+                sphere(r = 40);
+}
+
+// Cilindro central con domo arriba
+module central_core() {
+    // Cilindro principal
+    cylinder(r = dome_radius, h = dome_height, center = false);
+    
+    // Domo en la punta
+    translate([0, 0, dome_height])
+        scale([1, 1, 0.6])
+            sphere(r = dome_radius);
+    
+    // Base ensanchada
+    translate([0, 0, -200])
+        cylinder(r1 = dome_radius * 1.5, r2 = dome_radius, h = 200);
+}
+
+// -------- ENSAMBLE --------
+
+// Núcleo central
+color("DarkSlateGray") central_core();
+
+// 4 espirales como rampas continuas
+for (offset = spiral_offsets) {
+    color("DimGray") spiral_ramp(offset, 0, height_total);
+}
+
+// Domos en posiciones registradas
+for (dome = domes) {
+    pos = plate_xyz(spiral_offsets[dome[0]], dome[1]);
+    color("SteelBlue") dome_bump(pos);
+}
+
+// Domos sintéticos cada ~20 plates en cada espiral para poblar
+for (offset_idx = [0 : 3]) {
+    for (pi = [0 : 20 : plate_count - 1]) {
+        // Saltar los domos ya puestos
+        is_explicit = false;
+        for (dome = domes) {
+            if (dome[0] == offset_idx && dome[1] == pi) {
+                is_explicit = true;
+            }
+        }
+        if (!is_explicit) {
+            pos = plate_xyz(spiral_offsets[offset_idx], pi);
+            color("SlateGray") dome_bump(pos);
+        }
+    }
+}


### PR DESCRIPTION
## Cambios

### WorldRotator.gd
- **Sky sync throttled a 6 frames** con cache de Basis — evita recomputar Environment.background_sky_orientation cada frame
- **Continuous tracking con SLERP** en vez de snap directo — elimina saltos de cámara periódicos al moverse en modo centrífugo
- Smoothstep para deceleración natural, tasa escalada por rotation_speed

### OdiseaExterior.gd
- Guard en `_reset_camera_roll()` — solo escribe si rotation.z != 0
- Comentado `_tick_dome_facade_cursor()` como no-op (FD-041 ya lo parkea)

### models/odisea_lod.scad (nuevo)
- Mesh LOD combinado OpenSCAD: núcleo central + 4 espirales + domos
- Para reemplazar el MultiMesh LOD actual con un solo mesh
- Parámetros matchean TerraceSpiral.gd + DomeRegistry