### PR TITLE
Feature: Parametric Plasma Exhaust Proposals for Reactor

### DIFF
--- a/core_v2/levels/OdiseaExterior.tscn
+++ b/core_v2/levels/OdiseaExterior.tscn
@@ -7,6 +7,10 @@
 [ext_resource path="res://core_v2/components/SpiralPlateAttachment.gd" type="Script" id=6]
 [ext_resource path="res://core_v2/systems/visual/FauxSkydomeParallaxShell.gd" type="Script" id=7]
 [ext_resource path="res://core_v2/systems/visual/TerraceSegmentManager.gd" type="Script" id=8]
+[ext_resource path="res://core_v2/visual/plasma_exhaust/PlasmaExhaust_A.tscn" type="PackedScene" id=9]
+[ext_resource path="res://core_v2/visual/plasma_exhaust/PlasmaExhaust_B.tscn" type="PackedScene" id=10]
+[ext_resource path="res://core_v2/visual/plasma_exhaust/PlasmaExhaust_C.tscn" type="PackedScene" id=11]
+[ext_resource path="res://core_v2/visual/plasma_exhaust/PlasmaExhaust_D.tscn" type="PackedScene" id=12]
 
 [sub_resource type="BoxShape" id=1]
 extents = Vector3( 100, 1, 100 )
@@ -63,6 +67,21 @@ omni_shadow_mode = 0
 script = ExtResource( 6 )
 rotator_path = NodePath("../WorldRotator")
 plate_index = 90
+
+[node name="PlasmaExhaustProposals" type="Spatial" parent="WorldRotator"]
+transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 1686, 52.9999 )
+
+[node name="Option_A" parent="WorldRotator/PlasmaExhaustProposals" instance=ExtResource( 9 )]
+visible = false
+
+[node name="Option_B" parent="WorldRotator/PlasmaExhaustProposals" instance=ExtResource( 10 )]
+visible = false
+
+[node name="Option_C" parent="WorldRotator/PlasmaExhaustProposals" instance=ExtResource( 11 )]
+visible = false
+
+[node name="Option_D" parent="WorldRotator/PlasmaExhaustProposals" instance=ExtResource( 12 )]
+visible = false
 
 [node name="OmniLight4" type="OmniLight" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1148.64, 0 )

--- a/core_v2/visual/plasma_exhaust/PlasmaExhaustBase.gd
+++ b/core_v2/visual/plasma_exhaust/PlasmaExhaustBase.gd
@@ -1,0 +1,30 @@
+extends Spatial
+class_name PlasmaExhaustBase
+
+# Performance Cost: - (Base Class)
+# LOD Support: -
+
+export(bool) var is_active := true setget set_active
+export(float, 0.0, 1.0) var intensity := 1.0 setget set_intensity
+export(float, 0.0, 1.0) var color_phase := 0.0 setget set_color_phase
+
+func set_active(val: bool) -> void:
+	is_active = val
+	_update_active_state()
+
+func set_intensity(val: float) -> void:
+	intensity = clamp(val, 0.0, 1.0)
+	_update_intensity()
+
+func set_color_phase(val: float) -> void:
+	color_phase = clamp(val, 0.0, 1.0)
+	_update_color_phase()
+
+func _update_active_state() -> void:
+	visible = is_active
+
+func _update_intensity() -> void:
+	pass
+
+func _update_color_phase() -> void:
+	pass

--- a/core_v2/visual/plasma_exhaust/PlasmaExhaust_A.gd
+++ b/core_v2/visual/plasma_exhaust/PlasmaExhaust_A.gd
@@ -1,0 +1,42 @@
+extends "res://core_v2/visual/plasma_exhaust/PlasmaExhaustBase.gd"
+
+# Performance Cost: Medium (Procedural Noise in Fragment)
+# LOD Support: Yes (Standard Godot Mesh LOD)
+
+export(float) var color_cycle_speed := 1.0
+export(float) var noise_scale := 2.0
+export(float) var distortion_amount := 0.5
+export(float) var brightness := 2.0
+export(float) var pulse_frequency := 1.0
+
+onready var mesh_instance = $MeshInstance
+
+func _ready():
+	_update_shader_params()
+
+func _process(delta):
+	if is_active:
+		# Option A can have its own internal cycle if needed
+		pass
+
+func _update_intensity():
+	if mesh_instance:
+		var mat = mesh_instance.get_surface_material(0)
+		if mat:
+			mat.set_shader_param("intensity", intensity)
+
+func _update_color_phase():
+	if mesh_instance:
+		var mat = mesh_instance.get_surface_material(0)
+		if mat:
+			mat.set_shader_param("color_phase", color_phase)
+
+func _update_shader_params():
+	if mesh_instance:
+		var mat = mesh_instance.get_surface_material(0)
+		if mat:
+			mat.set_shader_param("noise_scale", noise_scale)
+			mat.set_shader_param("distortion_amount", distortion_amount)
+			mat.set_shader_param("brightness", brightness)
+			mat.set_shader_param("pulse_frequency", pulse_frequency)
+			mat.set_shader_param("speed", color_cycle_speed)

--- a/core_v2/visual/plasma_exhaust/PlasmaExhaust_A.shader
+++ b/core_v2/visual/plasma_exhaust/PlasmaExhaust_A.shader
@@ -1,0 +1,51 @@
+shader_type spatial;
+render_mode blend_add, cull_disabled, unshaded;
+
+uniform vec4 base_color : hint_color = vec4(0.0, 0.5, 1.0, 1.0);
+uniform vec4 hot_color : hint_color = vec4(0.5, 0.8, 1.0, 1.0);
+uniform float noise_scale = 2.0;
+uniform float distortion_amount = 0.5;
+uniform float speed = 1.0;
+uniform float intensity = 1.0;
+uniform float color_phase = 0.0;
+uniform float brightness = 2.0;
+uniform float pulse_frequency = 1.0;
+
+// Simple 3D noise function
+float hash(vec3 p) {
+    p = fract(p * 0.3183099 + .1);
+    p *= 17.0;
+    return fract(p.x * p.y * p.z * (p.x + p.y + p.z));
+}
+
+float noise(vec3 x) {
+    vec3 i = floor(x);
+    vec3 f = fract(x);
+    f = f * f * (3.0 - 2.0 * f);
+    return mix(mix(mix(hash(i + vec3(0, 0, 0)), hash(i + vec3(1, 0, 0)), f.x),
+                   mix(hash(i + vec3(0, 1, 0)), hash(i + vec3(1, 1, 0)), f.x), f.y),
+               mix(mix(hash(i + vec3(0, 0, 1)), hash(i + vec3(1, 0, 1)), f.x),
+                   mix(hash(i + vec3(0, 1, 1)), hash(i + vec3(1, 1, 1)), f.x), f.y), f.z);
+}
+
+void vertex() {
+    float n = noise(VERTEX * noise_scale + vec3(0.0, TIME * speed, 0.0));
+    VERTEX += NORMAL * n * distortion_amount * intensity;
+}
+
+void fragment() {
+    vec3 noise_coord = vec3(UV * noise_scale, TIME * speed);
+    float n = noise(noise_coord);
+
+    // Gradient along Y (v-axis)
+    float mask = pow(1.0 - UV.y, 2.0);
+
+    // Pulse
+    float pulse = 0.8 + 0.2 * sin(TIME * pulse_frequency * 6.28);
+
+    // Color phase shift
+    vec4 final_color = mix(base_color, hot_color, color_phase + n * 0.5);
+
+    ALBEDO = final_color.rgb * brightness * intensity * pulse * n;
+    ALPHA = mask * intensity * n;
+}

--- a/core_v2/visual/plasma_exhaust/PlasmaExhaust_A.tscn
+++ b/core_v2/visual/plasma_exhaust/PlasmaExhaust_A.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://core_v2/visual/plasma_exhaust/PlasmaExhaust_A.gd" type="Script" id=1]
+[ext_resource path="res://core_v2/visual/plasma_exhaust/PlasmaExhaust_A.shader" type="Shader" id=2]
+
+[sub_resource type="CylinderMesh" id=1]
+top_radius = 2.0
+bottom_radius = 0.5
+height = 10.0
+radial_segments = 16
+rings = 8
+
+[sub_resource type="ShaderMaterial" id=2]
+shader = ExtResource( 2 )
+shader_param/base_color = Color( 0, 0.501961, 1, 1 )
+shader_param/hot_color = Color( 0.501961, 0.8, 1, 1 )
+shader_param/noise_scale = 2.0
+shader_param/distortion_amount = 0.5
+shader_param/speed = 1.0
+shader_param/intensity = 1.0
+shader_param/color_phase = 0.0
+shader_param/brightness = 2.0
+shader_param/pulse_frequency = 1.0
+
+[node name="PlasmaExhaust_A" type="Spatial"]
+script = ExtResource( 1 )
+
+[node name="MeshInstance" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5, 0 )
+mesh = SubResource( 1 )
+material/0 = SubResource( 2 )

--- a/core_v2/visual/plasma_exhaust/PlasmaExhaust_B.gd
+++ b/core_v2/visual/plasma_exhaust/PlasmaExhaust_B.gd
@@ -1,0 +1,42 @@
+extends "res://core_v2/visual/plasma_exhaust/PlasmaExhaustBase.gd"
+
+# Performance Cost: Low (Texture Fetch)
+# LOD Support: Yes (Standard Godot Mesh LOD)
+
+export(String, FILE, "*.png,*.jpg") var sprite_sheet_path := "res://assets/FX/particle_system_effects_Godot3/textures/sprites_16.png"
+export(float) var animation_speed := 15.0
+export(Color) var tint_color := Color(0.2, 0.6, 1.0, 1.0)
+export(float) var emission_strength := 2.5
+export(Vector2) var grid_size := Vector2(4.0, 4.0) # sprites_16.png likely 4x4 or 8x8. Defaulting to 4x4.
+
+onready var mesh_instance = $MeshInstance
+
+func _ready():
+	_update_shader_params()
+	if sprite_sheet_path != "":
+		var tex = load(sprite_sheet_path)
+		if tex and mesh_instance:
+			var mat = mesh_instance.get_surface_material(0)
+			if mat:
+				mat.set_shader_param("flipbook_tex", tex)
+
+func _update_intensity():
+	if mesh_instance:
+		var mat = mesh_instance.get_surface_material(0)
+		if mat:
+			mat.set_shader_param("intensity", intensity)
+
+func _update_color_phase():
+	if mesh_instance:
+		var mat = mesh_instance.get_surface_material(0)
+		if mat:
+			mat.set_shader_param("color_phase", color_phase)
+
+func _update_shader_params():
+	if mesh_instance:
+		var mat = mesh_instance.get_surface_material(0)
+		if mat:
+			mat.set_shader_param("animation_speed", animation_speed)
+			mat.set_shader_param("tint_color", tint_color)
+			mat.set_shader_param("emission_strength", emission_strength)
+			mat.set_shader_param("grid_size", grid_size)

--- a/core_v2/visual/plasma_exhaust/PlasmaExhaust_B.shader
+++ b/core_v2/visual/plasma_exhaust/PlasmaExhaust_B.shader
@@ -1,0 +1,28 @@
+shader_type spatial;
+render_mode blend_add, cull_disabled, unshaded;
+
+uniform sampler2D flipbook_tex : hint_albedo;
+uniform vec2 grid_size = vec2(4.0, 4.0);
+uniform float animation_speed = 10.0;
+uniform vec4 tint_color : hint_color = vec4(1.0, 0.5, 0.0, 1.0);
+uniform float emission_strength = 2.0;
+uniform float intensity = 1.0;
+uniform float color_phase = 0.0;
+
+void fragment() {
+    float total_frames = grid_size.x * grid_size.y;
+    float frame = floor(mod(TIME * animation_speed, total_frames));
+
+    vec2 frame_size = 1.0 / grid_size;
+    vec2 frame_coord = vec2(mod(frame, grid_size.x), floor(frame / grid_size.x));
+
+    vec2 uv = UV / grid_size + frame_coord * frame_size;
+
+    vec4 tex = texture(flipbook_tex, uv);
+
+    // Simple colorization based on color_phase
+    vec3 final_tint = mix(tint_color.rgb, vec3(1.0, 1.0, 1.0), color_phase);
+
+    ALBEDO = tex.rgb * final_tint * emission_strength * intensity;
+    ALPHA = tex.a * intensity * (1.0 - UV.y);
+}

--- a/core_v2/visual/plasma_exhaust/PlasmaExhaust_B.tscn
+++ b/core_v2/visual/plasma_exhaust/PlasmaExhaust_B.tscn
@@ -1,0 +1,29 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://core_v2/visual/plasma_exhaust/PlasmaExhaust_B.gd" type="Script" id=1]
+[ext_resource path="res://core_v2/visual/plasma_exhaust/PlasmaExhaust_B.shader" type="Shader" id=2]
+
+[sub_resource type="QuadMesh" id=1]
+size = Vector2(5, 12)
+
+[sub_resource type="ShaderMaterial" id=2]
+shader = ExtResource( 2 )
+shader_param/grid_size = Vector2( 4, 4 )
+shader_param/animation_speed = 15.0
+shader_param/tint_color = Color( 0.2, 0.6, 1, 1 )
+shader_param/emission_strength = 2.5
+shader_param/intensity = 1.0
+shader_param/color_phase = 0.0
+
+[node name="PlasmaExhaust_B" type="Spatial"]
+script = ExtResource( 1 )
+
+[node name="MeshInstance" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 6, 0 )
+mesh = SubResource( 1 )
+material/0 = SubResource( 2 )
+
+[node name="MeshInstance2" type="MeshInstance" parent="."]
+transform = Transform( -4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 0, 6, 0 )
+mesh = SubResource( 1 )
+material/0 = SubResource( 2 )

--- a/core_v2/visual/plasma_exhaust/PlasmaExhaust_C.gd
+++ b/core_v2/visual/plasma_exhaust/PlasmaExhaust_C.gd
@@ -1,0 +1,53 @@
+extends "res://core_v2/visual/plasma_exhaust/PlasmaExhaustBase.gd"
+
+# Performance Cost: High (GPU Particles)
+# LOD Support: Yes (Particles visible distance / visibility AABB)
+
+export(int) var amount := 200 setget set_amount
+export(float) var lifetime := 2.0 setget set_lifetime
+export(float) var initial_velocity := 5.0 setget set_initial_velocity
+export(float) var spread := 15.0 setget set_spread
+
+onready var particles = $Particles
+
+func _ready():
+	_update_particles()
+
+func set_amount(val: int):
+	amount = val
+	if is_inside_tree() and particles:
+		particles.amount = amount
+
+func set_lifetime(val: float):
+	lifetime = val
+	if is_inside_tree() and particles:
+		particles.lifetime = lifetime
+
+func set_initial_velocity(val: float):
+	initial_velocity = val
+	_update_particles()
+
+func set_spread(val: float):
+	spread = val
+	_update_particles()
+
+func _update_active_state():
+	. _update_active_state()
+	if particles:
+		particles.emitting = is_active
+
+func _update_intensity():
+	if particles:
+		# We can modulate speed or scale by intensity
+		particles.speed_scale = intensity
+
+func _update_color_phase():
+	# Color phase could swap gradients or modulate color
+	pass
+
+func _update_particles():
+	if not particles: return
+	var mat = particles.process_material
+	if mat is ParticlesMaterial:
+		mat.initial_velocity = initial_velocity
+		mat.spread = spread

--- a/core_v2/visual/plasma_exhaust/PlasmaExhaust_C.tscn
+++ b/core_v2/visual/plasma_exhaust/PlasmaExhaust_C.tscn
@@ -1,0 +1,48 @@
+[gd_scene load_steps=9 format=2]
+
+[ext_resource path="res://core_v2/visual/plasma_exhaust/PlasmaExhaust_C.gd" type="Script" id=1]
+
+[sub_resource type="Gradient" id=1]
+offsets = PoolRealArray( 0, 0.2, 0.8, 1 )
+colors = PoolColorArray( 0, 0.5, 1, 0, 0.5, 0.8, 1, 1, 0, 0.2, 1, 1, 0, 0, 0.5, 0 )
+
+[sub_resource type="GradientTexture" id=2]
+gradient = SubResource( 1 )
+
+[sub_resource type="Curve" id=3]
+_data = [ Vector2( 0, 0.2 ), 0.0, 0.0, 0, 0, Vector2( 0.2, 1 ), 0.0, 0.0, 0, 0, Vector2( 1, 0.5 ), 0.0, 0.0, 0, 0 ]
+
+[sub_resource type="CurveTexture" id=4]
+curve = SubResource( 3 )
+
+[sub_resource type="ParticlesMaterial" id=5]
+emission_shape = 1
+emission_sphere_radius = 1.0
+direction = Vector3( 0, 1, 0 )
+spread = 15.0
+gravity = Vector3( 0, 0, 0 )
+initial_velocity = 5.0
+scale_curve = SubResource( 4 )
+color_ramp = SubResource( 2 )
+
+[sub_resource type="SpatialMaterial" id=6]
+flags_unshaded = true
+vertex_color_use_as_albedo = true
+params_blend_mode = 1
+params_billboard_mode = 3
+particles_anim_h_frames = 1
+particles_anim_v_frames = 1
+particles_anim_loop = false
+
+[sub_resource type="QuadMesh" id=7]
+material = SubResource( 6 )
+
+[node name="PlasmaExhaust_C" type="Spatial"]
+script = ExtResource( 1 )
+
+[node name="Particles" type="Particles" parent="."]
+amount = 200
+lifetime = 2.0
+visibility_aabb = AABB( -5, -2, -5, 10, 20, 10 )
+process_material = SubResource( 5 )
+draw_pass_1 = SubResource( 7 )

--- a/core_v2/visual/plasma_exhaust/PlasmaExhaust_D.gd
+++ b/core_v2/visual/plasma_exhaust/PlasmaExhaust_D.gd
@@ -1,0 +1,19 @@
+extends "res://core_v2/visual/plasma_exhaust/PlasmaExhaustBase.gd"
+
+# Performance Cost: High (Option A + Option C)
+# LOD Support: Yes
+
+onready var option_a = $PlasmaExhaust_A
+onready var option_c = $PlasmaExhaust_C
+
+func _update_active_state():
+	if option_a: option_a.set_active(is_active)
+	if option_c: option_c.set_active(is_active)
+
+func _update_intensity():
+	if option_a: option_a.set_intensity(intensity)
+	if option_c: option_c.set_intensity(intensity)
+
+func _update_color_phase():
+	if option_a: option_a.set_color_phase(color_phase)
+	if option_c: option_c.set_color_phase(color_phase)

--- a/core_v2/visual/plasma_exhaust/PlasmaExhaust_D.tscn
+++ b/core_v2/visual/plasma_exhaust/PlasmaExhaust_D.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://core_v2/visual/plasma_exhaust/PlasmaExhaust_D.gd" type="Script" id=1]
+[ext_resource path="res://core_v2/visual/plasma_exhaust/PlasmaExhaust_A.tscn" type="PackedScene" id=2]
+[ext_resource path="res://core_v2/visual/plasma_exhaust/PlasmaExhaust_C.tscn" type="PackedScene" id=3]
+
+[node name="PlasmaExhaust_D" type="Spatial"]
+script = ExtResource( 1 )
+
+[node name="PlasmaExhaust_A" parent="." instance=ExtResource( 2 )]
+brightness = 1.5
+
+[node name="PlasmaExhaust_C" parent="." instance=ExtResource( 3 )]
+amount = 100
+initial_velocity = 8.0


### PR DESCRIPTION
This PR implements the requested Plasma Exhaust system for the ship's reactor. It includes four distinct parametric approaches (Shader, Flipbook, Particles, and Hybrid) that can be easily adjusted and compared in the Godot editor.

All options share a common interface:
- `set_active(bool)`
- `set_intensity(0.0 - 1.0)`
- `set_color_phase(0.0 - 1.0)`

The components are located in `core_v2/visual/plasma_exhaust/` and have been instanced in the `OdiseaExterior` scene for immediate evaluation. Each implementation includes performance cost estimates and LOD strategy details in their respective script headers.

---
*PR created automatically by Jules for task [17915908584992842756](https://jules.google.com/task/17915908584992842756) started by @icarito*