### PR TITLE
ANNA V2 Remote Debugging API

### DIFF
--- a/core_v2/anna/v2/ANNAV2_Thread.gd
+++ b/core_v2/anna/v2/ANNAV2_Thread.gd
@@ -209,7 +209,14 @@ func _on_data():
 		if type == "handshake_ack":
 			print("[ANNAV2] Handshake ACK received")
 		elif type == "command":
-			_command_queue.push(msg)
+			var action = msg.get("action")
+			var args = msg.get("args", {})
+			var cmd_id = msg.get("id", "unknown")
+			_command_queue.push({
+				"action": action,
+				"args": args,
+				"id": cmd_id
+			})
 
 func _send_handshake():
 	var platform = "desktop"

--- a/odisea_central.py
+++ b/odisea_central.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import time
+import uuid
 from typing import Dict, Any
 
 from aiohttp import web, WSCloseCode
@@ -207,8 +208,10 @@ class OdiseaCentral:
         self.heartbeats: Dict[str, dict] = {} # player_id -> heartbeat
         self.last_update: Dict[str, float] = {} # player_id -> timestamp
         self.session_rate_limit: Dict[str, float] = {} # session_id -> last_heartbeat_time
-        self.active_peers = set() # set of active WebSocket objects
+        self.active_peers: Dict[web.WebSocketResponse, str] = {} # ws -> peer_id
+        self.peer_ws: Dict[str, web.WebSocketResponse] = {} # peer_id -> ws
         self.auth_fails: Dict[str, dict] = {} # ip -> {"ts": [failure timestamps], "locked_until": float}
+        self.pending_commands: Dict[str, asyncio.Future] = {} # command_id -> Future
 
         if STORE_GHOSTS and not os.path.exists(GHOSTS_DIR):
             os.makedirs(GHOSTS_DIR, exist_ok=True)
@@ -292,7 +295,6 @@ class OdiseaCentral:
 
         peer_id = None
         authenticated = False
-        self.active_peers.add(ws)
 
         logger.info("New peer connection attempt.")
 
@@ -310,6 +312,8 @@ class OdiseaCentral:
                                     authenticated = True
                                     peer_id = data.get("peer_id", "unknown")
                                     logger.info(f"Peer authenticated: {peer_id}")
+                                    self.active_peers[ws] = peer_id
+                                    self.peer_ws[peer_id] = ws
                                     await ws.send_json({"type": "handshake_ack", "status": "ok"})
                                 else:
                                     logger.warning(f"Peer authentication failed. Invalid token.")
@@ -345,13 +349,23 @@ class OdiseaCentral:
                             if STORE_GHOSTS:
                                 self._store_ghost(player_id, session_id, data)
 
+                        elif msg_type == "command_response":
+                            cmd_id = data.get("id")
+                            if cmd_id in self.pending_commands:
+                                fut = self.pending_commands.pop(cmd_id)
+                                if not fut.done():
+                                    fut.set_result(data)
+
                     except Exception as e:
                         logger.error(f"Error processing peer message: {e}")
                 elif msg.type == web.WSMsgType.ERROR:
                     logger.error(f"Peer connection closed with exception {ws.exception()}")
 
         finally:
-            self.active_peers.discard(ws)
+            if ws in self.active_peers:
+                pid = self.active_peers.pop(ws)
+                if self.peer_ws.get(pid) == ws:
+                    self.peer_ws.pop(pid, None)
             logger.info(f"Peer disconnected: {peer_id}")
 
         return ws
@@ -388,6 +402,64 @@ class OdiseaCentral:
         sessions = list(set(hb.get("session_id") for hb in self.heartbeats.values() if hb.get("session_id")))
         return web.json_response(sessions)
 
+    async def handle_command(self, request):
+        guard = self._auth_guard(request)
+        if guard is not None:
+            return guard
+
+        try:
+            body = await request.json()
+            action = body.get("action")
+            args = body.get("args", {})
+        except Exception:
+            return web.json_response({"error": "invalid_json"}, status=400)
+
+        if not action:
+            return web.json_response({"error": "missing_action"}, status=400)
+
+        # Forward to all connected peers (or find the one matching player_id if provided)
+        if not self.active_peers:
+            return web.json_response({"error": "no_peers_connected"}, status=503)
+
+        cmd_id = str(uuid.uuid4())[:8]
+        cmd = {
+            "type": "command",
+            "action": action,
+            "args": args,
+            "id": cmd_id
+        }
+
+        # Find target peer
+        target_ws = None
+        player_id = body.get("player_id") or args.get("player_id")
+        if player_id:
+            hb = self.heartbeats.get(player_id)
+            if hb:
+                target_peer_id = hb.get("peer_id")
+                if target_peer_id:
+                    target_ws = self.peer_ws.get(target_peer_id)
+
+        if not target_ws:
+            # Fallback: using first connected peer as per prompt instruction
+            target_ws = next(iter(self.active_peers.keys()))
+
+        # Create future for response
+        fut = asyncio.get_running_loop().create_future()
+        self.pending_commands[cmd_id] = fut
+
+        try:
+            await target_ws.send_json(cmd)
+            # Wait for response with 5s timeout
+            response = await asyncio.wait_for(fut, timeout=5.5)
+            return web.json_response(response)
+        except asyncio.TimeoutError:
+            self.pending_commands.pop(cmd_id, None)
+            return web.json_response({"error": "timeout", "message": "Peer/Godot took too long to respond"}, status=504)
+        except Exception as e:
+            self.pending_commands.pop(cmd_id, None)
+            logger.error(f"Command relay failed: {e}")
+            return web.json_response({"error": "relay_failed", "message": str(e)}, status=502)
+
     async def handle_health(self, request):
         # Public endpoint
         return web.json_response({
@@ -407,6 +479,7 @@ class OdiseaCentral:
             web.get('/ws', self.handle_ws),
             web.get('/status', self.handle_status),
             web.get('/sessions', self.handle_sessions),
+            web.post('/command', self.handle_command),
             web.get('/health', self.handle_health),
         ])
 

--- a/odisea_peer.py
+++ b/odisea_peer.py
@@ -13,6 +13,8 @@ from zeroconf.asyncio import AsyncZeroconf
 
 # Configuration from environment variables
 PEER_PORT = int(os.environ.get("PEER_PORT", 4999))
+ANNA_HOST = os.environ.get("ANNA_HOST", "127.0.0.1")
+ANNA_PORT = int(os.environ.get("ANNA_PORT", 5000))
 CENTRAL_WS_URL = os.environ.get("CENTRAL_WS_URL", "ws://35.182.238.36:5003/ws")
 # Dev-only default; PRODUCTION must set ODISEA_BRIDGE_TOKEN to a real secret. See FD-162.
 DEV_DEFAULT_TOKEN = "odisea-dev-insecure"
@@ -30,6 +32,8 @@ class OdiseaPeer:
         self.heartbeats: Dict[str, dict] = {}
         self.central_ws: Optional[ClientWebSocketResponse] = None
         self.zeroconf: Optional[AsyncZeroconf] = None
+        self.godot_ws: Optional[web.WebSocketResponse] = None
+        self.command_history = [] # timestamps of last commands for rate limiting
 
         logger.info(f"Initialized Peer: peer_id={self.peer_id}, hostname={self.hostname}, ip={self.ip_address}")
 
@@ -87,6 +91,19 @@ class OdiseaPeer:
                                 data = json.loads(msg.data)
                                 if data.get("type") == "handshake_ack":
                                     logger.info("Handshake with central successful.")
+                                elif data.get("type") == "command":
+                                    # Forward to Godot via established WS
+                                    if self.godot_ws and not self.godot_ws.closed:
+                                        logger.info(f"Relaying command from central: {data.get('action')} ({data.get('id')})")
+                                        await self.godot_ws.send_json(data)
+                                    else:
+                                        logger.warning("Central command received but no Godot client connected.")
+                                        await ws.send_json({
+                                            "type": "command_response",
+                                            "id": data.get("id"),
+                                            "ok": False,
+                                            "error": "Godot client not connected to peer"
+                                        })
                                 elif data.get("type") == "error":
                                     logger.error(f"Central error: {data.get('error')}")
                             elif msg.type in (web.WSMsgType.CLOSED, web.WSMsgType.ERROR):
@@ -102,35 +119,46 @@ class OdiseaPeer:
         await ws.prepare(request)
 
         logger.info("New Godot client connected via WebSocket.")
+        self.godot_ws = ws
 
         logged_type = False
-        async for msg in ws:
-            # Godot 3's WebSocketClient defaults to BINARY write mode, so heartbeats
-            # may arrive as BINARY frames carrying UTF-8 JSON. Accept both.
-            if msg.type in (web.WSMsgType.TEXT, web.WSMsgType.BINARY):
-                if not logged_type:
-                    logger.info(f"First WS frame type from client: {msg.type.name}")
-                    logged_type = True
-                try:
-                    raw = msg.data
-                    if isinstance(raw, (bytes, bytearray)):
-                        raw = raw.decode("utf-8")
-                    data = json.loads(raw)
-                    if data.get("type") == "heartbeat":
-                        player_id = data.get("player_id")
-                        if player_id:
-                            # Inject peer_id into heartbeat
-                            data["peer_id"] = self.peer_id
-                            self.heartbeats[player_id] = data
-                            # Relay flat heartbeat to central
+        try:
+            async for msg in ws:
+                # Godot 3's WebSocketClient defaults to BINARY write mode, so heartbeats
+                # may arrive as BINARY frames carrying UTF-8 JSON. Accept both.
+                if msg.type in (web.WSMsgType.TEXT, web.WSMsgType.BINARY):
+                    if not logged_type:
+                        logger.info(f"First WS frame type from client: {msg.type.name}")
+                        logged_type = True
+                    try:
+                        raw = msg.data
+                        if isinstance(raw, (bytes, bytearray)):
+                            raw = raw.decode("utf-8")
+                        data = json.loads(raw)
+                        msg_type = data.get("type")
+                        if msg_type == "heartbeat":
+                            player_id = data.get("player_id")
+                            if player_id:
+                                # Inject peer_id into heartbeat
+                                data["peer_id"] = self.peer_id
+                                self.heartbeats[player_id] = data
+                                # Relay flat heartbeat to central
+                                if self.central_ws and not self.central_ws.closed:
+                                    await self.central_ws.send_json(data)
+                        elif msg_type == "command_response":
+                            # Relay response back to central
                             if self.central_ws and not self.central_ws.closed:
+                                logger.info(f"Relaying command_response to central: {data.get('id')}")
                                 await self.central_ws.send_json(data)
-                except Exception as e:
-                    logger.error(f"Error handling message: {e}")
-            elif msg.type == web.WSMsgType.ERROR:
-                logger.error(f"WebSocket connection closed with exception {ws.exception()}")
+                    except Exception as e:
+                        logger.error(f"Error handling message: {e}")
+                elif msg.type == web.WSMsgType.ERROR:
+                    logger.error(f"WebSocket connection closed with exception {ws.exception()}")
+        finally:
+            if self.godot_ws == ws:
+                self.godot_ws = None
+            logger.info("Godot client disconnected.")
 
-        logger.info("Godot client disconnected.")
         return ws
 
     async def handle_index(self, request):
@@ -149,6 +177,54 @@ class OdiseaPeer:
     async def handle_sessions(self, request):
         sessions = list(set(hb.get("session_id") for hb in self.heartbeats.values() if hb.get("session_id")))
         return web.json_response(sessions)
+
+    async def handle_command(self, request):
+        # Rate limiting: 10 commands per second
+        now = time.time()
+        self.command_history = [t for t in self.command_history if now - t < 1.0]
+        if len(self.command_history) >= 10:
+            return web.json_response({"error": "rate_limited", "message": "Too many commands (max 10/s)"}, status=429)
+        self.command_history.append(now)
+
+        # Parse args from query string (GET) or body (POST)
+        if request.method == "GET":
+            action = request.query.get("action")
+            # For GET, we support simple path-based inspect or execute_script with ?script=
+            args = dict(request.query)
+            if "action" in args: del args["action"]
+        else:
+            try:
+                body = await request.json()
+                action = body.get("action")
+                args = body.get("args", {})
+            except Exception:
+                return web.json_response({"error": "invalid_json"}, status=400)
+
+        if not action:
+            return web.json_response({"error": "missing_action"}, status=400)
+
+        # Forward to ANNA MCP via TCP
+        command = {"action": action, "args": args, "id": str(uuid.uuid4())[:8]}
+
+        try:
+            reader, writer = await asyncio.wait_for(asyncio.open_connection(ANNA_HOST, ANNA_PORT), timeout=2.0)
+            writer.write((json.dumps(command) + "\n").encode())
+            await writer.drain()
+
+            response_data = await asyncio.wait_for(reader.readuntil(b"\n"), timeout=5.0)
+            writer.close()
+            await writer.wait_closed()
+
+            return web.json_response(json.loads(response_data.decode()))
+        except asyncio.TimeoutError:
+            return web.json_response({"error": "timeout", "message": "ANNA MCP took too long to respond"}, status=504)
+        except Exception as e:
+            logger.error(f"TCP Command forward failed: {e}")
+            return web.json_response({
+                "error": "ANNA MCP not available",
+                "message": str(e),
+                "hint": "Ensure Godot is running with ANNA enabled on Desktop/Android"
+            }, status=502)
 
     async def handle_health(self, request):
         return web.json_response({
@@ -170,6 +246,8 @@ class OdiseaPeer:
             web.get('/sessions', self.handle_sessions),
             web.get('/health', self.handle_health),
             web.get('/peers', self.handle_peers),
+            web.get('/command', self.handle_command),
+            web.post('/command', self.handle_command),
         ])
 
         runner = web.AppRunner(app)


### PR DESCRIPTION
This PR implements the remote debugging API for ANNA V2, allowing Odiseo and the dashboard to execute inspection and debugging commands remotely.

Key changes:
- `odisea_peer.py`: Added HTTP `/command` (GET/POST) that forwards to Godot's port 5000 via TCP. Implemented WebSocket relay for commands coming from the Central server. Added rate limiting (10/s) and timeout (5s).
- `odisea_central.py`: Added HTTP POST `/command` that relays to connected peers. Implemented peer discovery by `player_id` using heartbeats for targeted command delivery.
- `core_v2/anna/v2/ANNAV2_Thread.gd`: Added handling for `command` messages received over WebSocket from the Peer.
- Security: Commands like `execute_script` and `set_property` are restricted to debug/editor builds in `ANNAV2.gd` (existing logic).
- Compatibility: HTML5 fallback handled (no TCP support message returned by Peer).

---
*PR created automatically by Jules for task [974015958001271515](https://jules.google.com/task/974015958001271515) started by @icarito*