### PR TITLE
ci: web export depends on GDUnit3 tests passing first

### DIFF
--- a/.github/workflows/export_web.yml
+++ b/.github/workflows/export_web.yml
@@ -14,7 +14,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-tests:
+    name: Check tests passed
+    runs-on: ubuntu-latest
+    outputs:
+      tests-passed: ${{ steps.check.outputs.passed }}
+    steps:
+      - name: Check latest test run
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LAST_RUN=$(gh run list --workflow "GDUnit3 Tests" --branch ${{ github.ref_name }} --limit 1 --json conclusion,status --jq '.[0] // empty')
+          CONCLUSION=$(echo "$LAST_RUN" | jq -r '.conclusion // ""')
+          STATUS=$(echo "$LAST_RUN" | jq -r '.status // ""')
+          if [ "$CONCLUSION" = "success" ] || [ "$STATUS" = "completed" -a "$CONCLUSION" = "success" ]; then
+            echo "passed=true" >> $GITHUB_OUTPUT
+            echo "Tests passed!"
+          else
+            echo "passed=false" >> $GITHUB_OUTPUT
+            echo "Latest tests: conclusion=$CONCLUSION status=$STATUS - skipping web export"
+          fi
+
   build-and-deploy:
+    needs: [check-tests]
+    if: needs.check-tests.outputs.tests-passed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
**Cambio:** el workflow `export_web.yml` ahora antes de exportar verifica que la ultima ejecucion de los tests GDUnit3 haya sido exitosa en el mismo branch.

**Como funciona:**
- Se agrega un job `check-tests` que consulta `gh run list` para ver el ultimo run de `GDUnit3 Tests`
- Si los tests fallaron o estan en progreso, el web export se salta
- Si no hay tests corridos en ese branch aun, tambien se salta
- La logica usa `${{ github.token }}`, no requiere secrets adicionales

**Motivacion:** evitar desplegar un build web roto solo porque se mergeo codigo que no paso los tests.