### PR TITLE
ci: web export triggered by GDUnit3 tests passing on main

### DIFF
--- a/.github/workflows/export_web.yml
+++ b/.github/workflows/export_web.yml
@@ -1,8 +1,11 @@
 name: Exportar a Web y Desplegar en GitHub Pages
 
 on:
-  push:
-    branches: [ "main" ]
+  workflow_run:
+    workflows: ["GDUnit3 Tests"]
+    types:
+      - completed
+    branches: [ main ]
 
 permissions:
   contents: read
@@ -14,31 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-tests:
-    name: Check tests passed
-    runs-on: ubuntu-latest
-    outputs:
-      tests-passed: ${{ steps.check.outputs.passed }}
-    steps:
-      - name: Check latest test run
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          LAST_RUN=$(gh run list --workflow "GDUnit3 Tests" --branch ${{ github.ref_name }} --limit 1 --json conclusion,status --jq '.[0] // empty')
-          CONCLUSION=$(echo "$LAST_RUN" | jq -r '.conclusion // ""')
-          STATUS=$(echo "$LAST_RUN" | jq -r '.status // ""')
-          if [ "$CONCLUSION" = "success" ] || [ "$STATUS" = "completed" -a "$CONCLUSION" = "success" ]; then
-            echo "passed=true" >> $GITHUB_OUTPUT
-            echo "Tests passed!"
-          else
-            echo "passed=false" >> $GITHUB_OUTPUT
-            echo "Latest tests: conclusion=$CONCLUSION status=$STATUS - skipping web export"
-          fi
-
   build-and-deploy:
-    needs: [check-tests]
-    if: needs.check-tests.outputs.tests-passed == 'true'
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -69,8 +49,6 @@ jobs:
 
       - name: Move Web export to root
         run: |
-          # El action crea un subdirectorio con el nombre del preset (p.ej. HTML5).
-          # Mover todo al nivel superior para que Pages sirva index.html en la raíz.
           BUILD_DIR="${{ steps.export.outputs.build_directory }}"
           SRC_DIR=""
 

--- a/.github/workflows/export_web.yml
+++ b/.github/workflows/export_web.yml
@@ -14,7 +14,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-tests:
+    name: Check tests passed
+    runs-on: ubuntu-latest
+    outputs:
+      tests-passed: ${{ steps.check.outputs.passed }}
+    steps:
+      - name: Check latest test run
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LAST_RUN=$(gh run list --workflow "GDUnit3 Tests" --branch ${{ github.ref_name }} --limit 1 --json conclusion,status --jq '.[0] // empty')
+          CONCLUSION=$(echo "$LAST_RUN" | jq -r '.conclusion // ""')
+          STATUS=$(echo "$LAST_RUN" | jq -r '.status // ""')
+          if [ "$CONCLUSION" = "success" ] || [ "$STATUS" = "completed" -a "$CONCLUSION" = "success" ]; then
+            echo "passed=true" >> $GITHUB_OUTPUT
+            echo "Tests passed!"
+          else
+            echo "passed=false" >> $GITHUB_OUTPUT
+            echo "Latest tests: conclusion=$CONCLUSION status=$STATUS - skipping web export"
+          fi
+
   build-and-deploy:
+    needs: [check-tests]
+    if: needs.check-tests.outputs.tests-passed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
**Cambio:** el workflow `export_web.yml` ahora se dispara automaticamente cuando el workflow `GDUnit3 Tests` termina exitosamente en `main`.

**Como funciona:**
- `workflow_run` trigger: cuando GDUnit3 Tests completa en `main`, GitHub corre el web export
- Si los tests fallaron → el export se salta (`if: conclusion == success`)
- Si los tests pasaron → export a GitHub Pages como siempre
- Si alguien pushea directo a `main` sin correr tests, no pasa nada — el export nunca se dispara

**Ventajas sobre el approach anterior (check-tests con gh run list):**
- Sin race conditions: GitHub garantiza que el workflow de tests termino antes de empezar el export
- Sin polling: el trigger es nativo de GitHub Actions
- Sin falsos positivos: el export solo corre cuando los tests efectivamente terminaron bien
- Sin push directo: podes mergear PRs tranquilo, si no hay tests no hay deploy