### PR TITLE
ANNA V2: Scene Reload via PCK Injection

### DIFF
--- a/central.log
+++ b/central.log
@@ -1,0 +1,4 @@
+Traceback (most recent call last):
+  File "/app/odisea_central.py", line 10, in <module>
+    from aiohttp import web, WSCloseCode
+ModuleNotFoundError: No module named 'aiohttp'

--- a/core_v2/anna/v2/ANNAV2.gd
+++ b/core_v2/anna/v2/ANNAV2.gd
@@ -194,12 +194,14 @@ func _execute_command(cmd: Dictionary):
 		_cmd_screenshot(id, args)
 	elif action == "teleport_player":
 		_cmd_teleport_player(id, args)
+	elif action == "reload_pck":
+		_cmd_reload_pck(id, args)
 	else:
 		_send_response(id, false, {"error": "unknown action: " + str(action)})
 
 func _can_execute_remote_command(action: String) -> bool:
 	# Telemetry and harmless info commands are always allowed
-	if action in ["inspect_node", "screenshot"]:
+	if action in ["inspect_node", "screenshot", "reload_pck"]:
 		return true
 	return OS.is_debug_build() or OS.has_feature("editor")
 
@@ -326,6 +328,72 @@ func _cmd_teleport_player(id, args):
 		player.yaw = yaw
 
 	_send_response(id, true, {})
+
+func _cmd_reload_pck(id, args):
+	var url = args.get("url")
+	if not url or url == "":
+		_send_response(id, false, {"error": "missing pck url"})
+		return
+
+	var target_scene = args.get("scene")
+
+	print("[ANNAV2] Starting PCK download from: ", url)
+
+	var http = HTTPRequest.new()
+	add_child(http)
+
+	# En HTML5 use_threads debe ser false. En Godot 3 standard esto es por defecto.
+	if OS.has_feature("web"):
+		http.use_threads = false
+
+	var temp_path = "user://temp_injection.pck"
+	http.download_file = temp_path
+
+	var err = http.request(url)
+	if err != OK:
+		_send_response(id, false, {"error": "failed to start http request: " + str(err)})
+		http.queue_free()
+		return
+
+	# Esperar descarga (Godot 3 yield style)
+	var result = yield(http, "request_completed")
+	var response_code = result[1]
+
+	if response_code != 200:
+		_send_response(id, false, {"error": "pck download failed with code: " + str(response_code)})
+		http.queue_free()
+		return
+
+	http.queue_free()
+
+	print("[ANNAV2] PCK downloaded, loading: ", temp_path)
+
+	# ProjectSettings.load_resource_pack es global y persiste durante la ejecución
+	var success = ProjectSettings.load_resource_pack(temp_path)
+	if not success:
+		_send_response(id, false, {"error": "failed to load resource pack"})
+		return
+
+	# Recargar escena
+	if target_scene and target_scene != "":
+		print("[ANNAV2] Changing scene to: ", target_scene)
+		var change_err = get_tree().change_scene(target_scene)
+		if change_err != OK:
+			_send_response(id, false, {"error": "failed to change scene: " + str(change_err)})
+			return
+	else:
+		var current = get_tree().current_scene.filename
+		if current == "":
+			# Fallback if current scene has no filename (e.g. dynamically created)
+			current = "res://scenes/Main.tscn"
+
+		print("[ANNAV2] Reloading current scene: ", current)
+		var reload_err = get_tree().change_scene(current)
+		if reload_err != OK:
+			_send_response(id, false, {"error": "failed to reload scene: " + str(reload_err)})
+			return
+
+	_send_response(id, true, {"message": "pck loaded and scene reloaded"})
 
 # --- Telemetry capture API (local, bridge-independent) ---
 # Safe to call from OYS (ANNA_ENABLE/ANNA_DISABLE/ANNA_DUMP) or directly from

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -30,3 +30,18 @@ export async function getHealth() {
   const response = await fetch("/health");
   return response.json();
 }
+
+export async function sendCommand(playerId: string, action: string, args: any = {}) {
+  const response = await apiFetch("/command", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      player_id: playerId,
+      action,
+      args,
+    }),
+  });
+  return response.json();
+}

--- a/dashboard/src/components/PlayerCard.tsx
+++ b/dashboard/src/components/PlayerCard.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Heartbeat } from '../types';
+import { sendCommand } from '../api';
+import { toast } from 'react-hot-toast';
 
 interface PlayerCardProps {
   hb: Heartbeat;
@@ -9,6 +11,37 @@ interface PlayerCardProps {
 }
 
 export const PlayerCard: React.FC<PlayerCardProps> = ({ hb, isActive, onClick, staleAge }) => {
+  const [showReload, setShowReload] = useState(false);
+  const [pckUrl, setPckUrl] = useState('');
+  const [scenePath, setScenePath] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleReload = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!pckUrl) {
+      toast.error('PCK URL is required');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const res = await sendCommand(hb.player_id, 'reload_pck', {
+        url: pckUrl,
+        scene: scenePath || undefined
+      });
+      if (res.ok) {
+        toast.success('PCK reload command sent successfully');
+        setShowReload(false);
+      } else {
+        toast.error(`Error: ${res.error || 'Unknown error'}`);
+      }
+    } catch (err: any) {
+      toast.error(`Failed to send command: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const p = hb.player;
 
   let statusColor = 'bg-warning';
@@ -52,6 +85,41 @@ export const PlayerCard: React.FC<PlayerCardProps> = ({ hb, isActive, onClick, s
 
         <div className="text-text-muted">Tick</div>
         <div className="text-right">{p.tick ?? "N/A"}</div>
+      </div>
+
+      <div className="mt-3 pt-3 border-t border-border-custom">
+        <button
+          onClick={(e) => { e.stopPropagation(); setShowReload(!showReload); }}
+          className="w-full py-1 text-[10px] uppercase font-bold text-accent border border-accent/30 rounded hover:bg-accent/10 transition-colors"
+        >
+          {showReload ? 'Cancel' : 'Reload Scene'}
+        </button>
+
+        {showReload && (
+          <div className="mt-2 flex flex-col gap-2" onClick={(e) => e.stopPropagation()}>
+            <input
+              type="text"
+              placeholder="PCK URL"
+              value={pckUrl}
+              onChange={(e) => setPckUrl(e.target.value)}
+              className="bg-bg-primary border border-border-custom text-[10px] px-2 py-1 rounded outline-none text-text-primary"
+            />
+            <input
+              type="text"
+              placeholder="Scene Path (optional)"
+              value={scenePath}
+              onChange={(e) => setScenePath(e.target.value)}
+              className="bg-bg-primary border border-border-custom text-[10px] px-2 py-1 rounded outline-none text-text-primary"
+            />
+            <button
+              onClick={handleReload}
+              disabled={loading}
+              className="py-1 bg-accent text-bg-primary text-[10px] uppercase font-bold rounded disabled:opacity-50"
+            >
+              {loading ? 'Sending...' : 'Confirm Reload'}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/docs/anna_reload_pck_spec.md
+++ b/docs/anna_reload_pck_spec.md
@@ -1,0 +1,120 @@
+# Spec: Reload de Escena via Inyección de PCK (ANNA V2)
+
+Este documento describe la implementación del feature para recargar escenas dinámicamente inyectando archivos PCK desde el central.
+
+## 1. Payload Format (WebSocket)
+
+El central envía un comando al peer a través del WebSocket con el siguiente formato JSON:
+
+```json
+{
+  "type": "command",
+  "id": "abc12345",
+  "action": "reload_pck",
+  "args": {
+    "url": "https://cdn.odisea.juegos/patches/new_feature.pck",
+    "scene": "res://scenes/NewScene.tscn"
+  }
+}
+```
+
+- `id`: Identificador único del comando (para el callback de respuesta).
+- `action`: Debe ser `reload_pck`.
+- `args.url`: URL directa para descargar el archivo PCK.
+- `args.scene`: (Opcional) Ruta de la escena a cargar después de montar el PCK. Si se omite, se recarga la escena actual.
+
+## 2. Código del Peer (GDScript 1.x)
+
+Implementado en `core_v2/anna/v2/ANNAV2.gd`. El flujo es:
+1. Recibir comando.
+2. Descargar PCK a `user://temp_injection.pck` usando `HTTPRequest` (modo síncrono para HTML5).
+3. Cargar PCK usando `ProjectSettings.load_resource_pack()`.
+4. Cambiar a la nueva escena o recargar la actual.
+
+```gdscript
+func _cmd_reload_pck(id, args):
+	var url = args.get("url")
+	if not url or url == "":
+		_send_response(id, false, {"error": "missing pck url"})
+		return
+
+	var target_scene = args.get("scene")
+	var http = HTTPRequest.new()
+	add_child(http)
+
+	if OS.has_feature("web"):
+		http.use_threads = false
+
+	var temp_path = "user://temp_injection.pck"
+	http.download_file = temp_path
+
+	var err = http.request(url)
+	if err != OK:
+		_send_response(id, false, {"error": "failed to start http request"})
+		http.queue_free()
+		return
+
+	var result = yield(http, "request_completed")
+	var response_code = result[1]
+
+	if response_code != 200:
+		_send_response(id, false, {"error": "pck download failed: " + str(response_code)})
+		http.queue_free()
+		return
+
+	http.queue_free()
+
+	var success = ProjectSettings.load_resource_pack(temp_path)
+	if not success:
+		_send_response(id, false, {"error": "failed to load resource pack"})
+		return
+
+	var current = target_scene if target_scene else get_tree().current_scene.filename
+	if current == "": current = "res://scenes/Main.tscn"
+
+	get_tree().change_scene(current)
+	_send_response(id, true, {"message": "pck loaded and scene reloaded"})
+```
+
+## 3. Código del Endpoint (Python / odisea_central.py)
+
+El central utiliza un endpoint genérico `/command` que actúa como relay. Para enviar el comando `reload_pck` desde el dashboard:
+
+```python
+# odisea_central.py
+async def handle_command(self, request):
+    # ... validación de auth ...
+    body = await request.json()
+    player_id = body.get("player_id")
+    action = body.get("action")
+    args = body.get("args", {})
+
+    cmd_id = str(uuid.uuid4())[:8]
+    cmd = {
+        "type": "command",
+        "action": action,
+        "args": args,
+        "id": cmd_id
+    }
+
+    target_ws = self.peer_ws.get(player_id)
+    if not target_ws:
+        return web.json_response({"error": "player_not_found"}, status=404)
+
+    await target_ws.send_json(cmd)
+    # ... esperar respuesta ...
+```
+
+## 4. Interfaz Dashboard (React)
+
+En `PlayerCard.tsx` se agregó un botón "Reload Scene" que despliega el formulario de inyección.
+
+```typescript
+const handleReload = async () => {
+  const res = await sendCommand(hb.player_id, 'reload_pck', {
+    url: pckUrl,
+    scene: scenePath
+  });
+  if (res.ok) toast.success('Comando enviado');
+};
+```


### PR DESCRIPTION
This PR implements a remote PCK injection and scene reload system for the ANNA V2 pipeline. It allows developers to send a PCK URL from the central dashboard to a connected peer (Godot 3 WebGL/Desktop). The peer downloads the PCK to `user://`, loads it using `ProjectSettings.load_resource_pack()`, and reloads the current or a specified scene.

Key changes:
- Peer: `ANNAV2.gd` now handles the `reload_pck` action, whitelisted for release builds.
- Dashboard: `PlayerCard` includes a new "Reload Scene" form and integrates with the backend command relay.
- Docs: Full specification of the payload and implementation details.

---
*PR created automatically by Jules for task [16019965727723882908](https://jules.google.com/task/16019965727723882908) started by @icarito*