### PR TITLE
Add FireEmitter and RetractableBridge props

### DIFF
--- a/core_v2/props/FireEmitter.gd
+++ b/core_v2/props/FireEmitter.gd
@@ -1,142 +1,77 @@
-extends Spatial
+tool
+extends Area
 class_name FireEmitter
 
-# FireEmitter.gd - Fire hazard with area damage.
-# Adapted from LeakEmitter.gd API but uses GasParticleManager for particles.
+signal damage_tick(damage)
+signal extinguished()
 
-export(bool) var auto_start := true
-export(int) var burst_count := 3
-export(float) var burst_duration := 2.0
-export(float) var burst_interval := 8.0
-export(float) var fadeout_time := 3.0
-export(float) var damage_per_second := 10.0
-export(float) var damage_radius := 3.0
-export(bool) var continuous := false
+export(bool) var is_active: bool = true setget set_active
+export(float) var damage_per_tick: float = 10.0
+export(float) var tick_interval: float = 0.5
 
-onready var _manager: GasParticleManager = get_node_or_null("GasParticleManager")
-onready var _damage_area: Area = get_node_or_null("DamageArea")
-onready var _damage_shape: CollisionShape = get_node_or_null("DamageArea/CollisionShape")
-onready var _audio: AudioStreamPlayer3D = get_node_or_null("FireSound")
+var _tick_timer: float = 0.0
+var _player_body: Node = null
 
-var _is_emitting_logic := false
-var _time_passed := 0.0
-var _emission_weight := 0.0
-var _current_bursts := 0
-var _burst_active := false
-
-func _init():
-	add_to_group("replay_sync")
+onready var _particles: Particles = get_node_or_null("Particles")
+onready var _collision_shape: CollisionShape = get_node_or_null("CollisionShape")
 
 func _ready():
-	if _damage_shape and _damage_shape.shape is SphereShape:
-		_damage_shape.shape = _damage_shape.shape.duplicate()
-		(_damage_shape.shape as SphereShape).radius = damage_radius
+	connect("body_entered", self, "_on_body_entered")
+	connect("body_exited", self, "_on_body_exited")
 
-	if auto_start:
-		start_emission()
+	if not Engine.editor_hint:
+		_set_visuals_active(is_active)
+		if _collision_shape:
+			_collision_shape.disabled = not is_active
+	else:
+		_set_visuals_active(is_active)
 
-func start_emission():
-	_is_emitting_logic = true
-	_time_passed = 0.0
-	_current_bursts = 0
-	_burst_active = false
+func _process(delta: float):
+	if Engine.editor_hint:
+		return
 
-func stop_emission():
-	_is_emitting_logic = false
+	if is_active and _player_body:
+		_tick_timer += delta
+		if _tick_timer >= tick_interval:
+			_tick_timer = 0.0
+			emit_signal("damage_tick", damage_per_tick)
+
+func _on_body_entered(body: Node):
+	if body.is_in_group("player"):
+		_player_body = body
+		# Optional: apply first tick immediately?
+		# Prompt says "cada 0.5s mientras esté dentro".
+		# I'll reset timer to 0 to wait 0.5s for first tick.
+		_tick_timer = 0.0
+
+func _on_body_exited(body: Node):
+	if body == _player_body:
+		_player_body = null
+
+func set_active(value: bool):
+	is_active = value
+	_set_visuals_active(is_active)
+	if _collision_shape:
+		_collision_shape.set_deferred("disabled", not is_active)
+	if not is_active:
+		_player_body = null
+
+func _set_visuals_active(active: bool):
+	if _particles:
+		_particles.emitting = active
+
+func extinguish():
+	set_active(false)
+	emit_signal("extinguished()")
+
+func interact():
+	toggle()
+
+func activate():
+	set_active(true)
+
+func deactivate():
+	set_active(false)
 
 func toggle():
-	if _is_emitting_logic: stop_emission()
-	else: start_emission()
-
-func _on_button_activated():
-	stop_emission()
-
-func _physics_process(delta: float):
-	if Engine.editor_hint: return
-	step(delta)
-
-func step(delta: float):
-	_update_state(delta)
-	if _emission_weight > 0.05:
-		_spawn_particles(delta)
-		_apply_damage(delta)
-	_update_audio()
-
-func _update_state(delta: float):
-	if continuous:
-		if _is_emitting_logic:
-			_emission_weight = min(1.0, _emission_weight + delta * 4.0)
-		else:
-			_emission_weight = max(0.0, _emission_weight - delta / max(fadeout_time, 0.1))
-	else:
-		if _is_emitting_logic:
-			if burst_count > 0 and _current_bursts >= burst_count:
-				_is_emitting_logic = false
-				return
-
-			_time_passed += delta
-			var cycle = burst_duration + burst_interval
-			var t = fmod(_time_passed, cycle)
-
-			if t < burst_duration:
-				if not _burst_active:
-					_burst_active = true
-				_emission_weight = min(1.0, _emission_weight + delta * 5.0)
-			else:
-				if _burst_active:
-					_burst_active = false
-					_current_bursts += 1
-				_emission_weight = max(0.0, _emission_weight - delta * 2.0)
-		else:
-			_emission_weight = max(0.0, _emission_weight - delta / max(fadeout_time, 0.1))
-
-func _spawn_particles(delta: float):
-	if not _manager: return
-
-	# Roughly 60 particles per second at full strength for fire
-	var rate = 60.0 * _emission_weight
-	var count = int(rate * delta)
-	if randf() < fmod(rate * delta, 1.0):
-		count += 1
-
-	for i in range(count):
-		var pos = Vector3(rand_range(-0.2, 0.2), 0, rand_range(-0.2, 0.2))
-		# Initial velocity
-		var vel = Vector3(rand_range(-0.4, 0.4), rand_range(0.5, 1.5), rand_range(-0.4, 0.4)) * (0.8 + 0.2 * _emission_weight)
-		_manager.emit_particle(pos, vel, 1.0 + randf() * 0.5, 1.2 + randf() * 0.6)
-
-func _apply_damage(delta: float):
-	if not _damage_area or damage_per_second <= 0: return
-
-	var bodies = _damage_area.get_overlapping_bodies()
-	if bodies.empty(): return
-
-	var effective_damage = damage_per_second * _emission_weight * delta
-	for body in bodies:
-		if body.has_method("take_damage"):
-			body.take_damage(effective_damage)
-
-func _update_audio():
-	if not _audio: return
-	if _emission_weight > 0.01:
-		if not _audio.playing: _audio.play()
-		_audio.unit_db = lerp(-15.0, 10.0, _emission_weight)
-	else:
-		if _audio.playing: _audio.stop()
-
-func get_snapshot() -> Dictionary:
-	return {
-		"emitting": _is_emitting_logic,
-		"time": _time_passed,
-		"weight": _emission_weight,
-		"bursts": _current_bursts,
-		"b_active": _burst_active
-	}
-
-func restore_snapshot(data: Dictionary):
-	_is_emitting_logic = data.get("emitting", false)
-	_time_passed = data.get("time", 0.0)
-	_emission_weight = data.get("weight", 0.0)
-	_current_bursts = data.get("bursts", 0)
-	_burst_active = data.get("b_active", false)
-	_update_audio()
+	set_active(!is_active)

--- a/core_v2/props/FireEmitter.gd
+++ b/core_v2/props/FireEmitter.gd
@@ -16,6 +16,7 @@ onready var _particles: Particles = get_node_or_null("Particles")
 onready var _collision_shape: CollisionShape = get_node_or_null("CollisionShape")
 
 func _ready():
+	add_to_group("replay_sync")
 	connect("body_entered", self, "_on_body_entered")
 	connect("body_exited", self, "_on_body_exited")
 
@@ -75,3 +76,19 @@ func deactivate():
 
 func toggle():
 	set_active(!is_active)
+
+# --- SNAPSHOT SYSTEM ---
+
+func get_snapshot() -> Dictionary:
+	return {
+		"is_active": is_active,
+		"tick_timer": _tick_timer
+	}
+
+func restore_snapshot(data: Dictionary):
+	is_active = data.get("is_active", true)
+	_tick_timer = data.get("tick_timer", 0.0)
+
+	_set_visuals_active(is_active)
+	if _collision_shape:
+		_collision_shape.disabled = not is_active

--- a/core_v2/props/FireEmitter.tscn
+++ b/core_v2/props/FireEmitter.tscn
@@ -1,37 +1,57 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://core_v2/props/FireEmitter.gd" type="Script" id=1]
-[ext_resource path="res://core_v2/systems/gas/GasParticleManager.gd" type="Script" id=2]
-[ext_resource path="res://assets/sfx/sfx100v2_loop_ambient_01.ogg" type="AudioStream" id=3]
 
-[sub_resource type="SphereShape" id=1]
-radius = 3.0
+[sub_resource type="CylinderShape" id=1]
+radius = 1.0
+height = 2.0
 
-[node name="FireEmitter" type="Spatial"]
+[sub_resource type="Gradient" id=2]
+offsets = PoolRealArray( 0, 0.2, 0.5, 0.8, 1 )
+colors = PoolColorArray( 1, 1, 0, 1, 1, 0.5, 0, 1, 1, 0, 0, 1, 0.2, 0.2, 0.2, 1, 0, 0, 0, 0 )
+
+[sub_resource type="GradientTexture" id=3]
+gradient = SubResource( 2 )
+
+[sub_resource type="Curve" id=4]
+_data = [ Vector2( 0, 0.2 ), 0.0, 0.0, 0, 0, Vector2( 0.2, 1 ), 0.0, 0.0, 0, 0, Vector2( 1, 0.5 ), 0.0, 0.0, 0, 0 ]
+
+[sub_resource type="CurveTexture" id=5]
+curve = SubResource( 4 )
+
+[sub_resource type="ParticlesMaterial" id=6]
+emission_shape = 1
+emission_sphere_radius = 0.5
+direction = Vector3( 0, 1, 0 )
+spread = 10.0
+gravity = Vector3( 0, 2, 0 )
+initial_velocity = 2.0
+angular_velocity = 40.0
+angular_velocity_random = 1.0
+scale_curve = SubResource( 5 )
+color_ramp = SubResource( 3 )
+
+[sub_resource type="SpatialMaterial" id=7]
+flags_unshaded = true
+vertex_color_use_as_albedo = true
+params_blend_mode = 1
+params_billboard_mode = 3
+particles_anim_h_frames = 1
+particles_anim_v_frames = 1
+particles_anim_loop = false
+
+[sub_resource type="PointMesh" id=8]
+material = SubResource( 7 )
+
+[node name="FireEmitter" type="Area"]
 script = ExtResource( 1 )
 
-[node name="GasParticleManager" type="Spatial" parent="."]
-script = ExtResource( 2 )
-pool_size = 64
-default_max_lifetime = 2.0
-default_base_scale = 1.5
-viscosity = 0.5
-buoyancy = 1.5
-decay_rate = 1.5
-default_color = Color( 1, 0.490196, 0.117647, 0.8 )
-ignition_color = Color( 0.996078, 0.988235, 0.941176, 0.8 )
-world_collision_mask = 255
-default_atlas_path = "res://assets/flipbook_particles/assets/fireballs/fireball_02/textures/fireball_02.png"
-
-[node name="DamageArea" type="Area" parent="."]
-collision_layer = 0
-collision_mask = 2
-
-[node name="CollisionShape" type="CollisionShape" parent="DamageArea"]
+[node name="CollisionShape" type="CollisionShape" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0 )
 shape = SubResource( 1 )
 
-[node name="FireSound" type="AudioStreamPlayer3D" parent="."]
-stream = ExtResource( 3 )
-unit_db = 10.0
-unit_size = 3.0
-max_distance = 40.0
+[node name="Particles" type="Particles" parent="."]
+amount = 50
+lifetime = 1.5
+process_material = SubResource( 6 )
+draw_pass_1 = SubResource( 8 )

--- a/core_v2/props/RetractableBridge.gd
+++ b/core_v2/props/RetractableBridge.gd
@@ -33,6 +33,7 @@ onready var _arm: AnimatableBody = get_node_or_null("Base/Arm")
 onready var _platform: AnimatableBody = get_node_or_null("Base/Arm/Platform")
 
 func _ready():
+	add_to_group("replay_sync")
 	_update_layout()
 	if not Engine.editor_hint:
 		set_physics_process(true)
@@ -177,3 +178,44 @@ func _update_layout():
 func interact():
 	if _is_extended: retract()
 	else: extend()
+
+# --- SNAPSHOT SYSTEM ---
+
+func get_snapshot() -> Dictionary:
+	return {
+		"target_extended": _target_extended,
+		"is_extended": _is_extended,
+		"is_moving": _is_moving,
+		"current_step": _current_step,
+		"step_timer": _step_timer
+	}
+
+func restore_snapshot(data: Dictionary):
+	_target_extended = data.get("target_extended", false)
+	_is_extended = data.get("is_extended", false)
+	_is_moving = data.get("is_moving", false)
+	_current_step = data.get("current_step", 0)
+	_step_timer = data.get("step_timer", 0.0)
+
+	_update_layout()
+
+	# Explicitly update visuals based on current state
+	if not _is_moving:
+		_update_transforms(1.0 if _is_extended else 0.0)
+	else:
+		# If moving, we need to manually call the appropriate update logic
+		# for the current step to restore visuals mid-animation.
+		var total_steps = extend_steps if _target_extended else retract_steps
+		var ratio = float(_current_step) / float(total_steps)
+		if _target_extended:
+			_update_transforms(ratio)
+		else:
+			var half_steps = total_steps / 2
+			if _current_step <= half_steps:
+				var p_ratio = 1.0 - (float(_current_step) / float(half_steps))
+				_update_platform(p_ratio)
+				_update_arm(1.0) # Arm should be fully extended during platform retraction
+			else:
+				var a_ratio = 1.0 - (float(_current_step - half_steps) / float(total_steps - half_steps))
+				_update_arm(a_ratio)
+				_update_platform(0.0) # Platform should be retracted during arm rotation

--- a/core_v2/props/RetractableBridge.gd
+++ b/core_v2/props/RetractableBridge.gd
@@ -18,15 +18,8 @@ var _is_moving: bool = false
 var _target_extended: bool = false
 var _current_step: int = 0
 var _step_timer: float = 0.0
-# Target ~15s total for 30 steps as per user's prompt (30 steps * ~0.5s per step?)
-# Wait, user said: "30 pasos * ~0.016s = ~0.5s por step, total ~15s para extension completa"
-# 30 * 0.016 is 0.48s total.
-# "total ~15s para extension completa" suggests each step is 0.5s.
-# 30 steps * 0.5s = 15s.
-# 0.5s is roughly 30 frames at 60fps.
-# I will use a configurable step duration, or just follow the "total 15s" hint.
-# Let's assume step_duration = 0.5s.
-var _step_duration: float = 0.5
+# 30 steps at 60fps = ~0.5s total duration.
+var _step_duration: float = 1.0 / 60.0
 
 onready var _base: StaticBody = get_node_or_null("Base")
 onready var _arm: AnimatableBody = get_node_or_null("Base/Arm")
@@ -106,8 +99,9 @@ func extend():
 	_target_extended = true
 	_is_moving = true
 	_current_step = 0
-	_step_timer = _step_duration # Start first step immediately or after one duration?
-	# User says "cada step debe interpolar". I'll start at 0.
+	# Reactive: execute first step immediately
+	_step_timer = 0.0
+	_execute_step()
 
 func retract():
 	if not _is_extended or (_is_moving and not _target_extended):
@@ -115,7 +109,9 @@ func retract():
 	_target_extended = false
 	_is_moving = true
 	_current_step = 0
-	_step_timer = _step_duration
+	# Reactive: execute first step immediately
+	_step_timer = 0.0
+	_execute_step()
 
 func set_side(v):
 	side = v
@@ -153,22 +149,31 @@ func _update_layout():
 	var arm_mesh = _arm.get_node_or_null("MeshInstance")
 	var arm_col = _arm.get_node_or_null("CollisionShape")
 	if arm_mesh and arm_mesh.mesh is CubeMesh:
-		arm_mesh.mesh = arm_mesh.mesh.duplicate()
+		# Only duplicate if we are at runtime or if we haven't made it local yet
+		if not Engine.editor_hint or not arm_mesh.mesh.resource_local_to_scene:
+			arm_mesh.mesh = arm_mesh.mesh.duplicate()
+			if Engine.editor_hint: arm_mesh.mesh.resource_local_to_scene = true
 		arm_mesh.mesh.size.x = arm_length
 		arm_mesh.transform.origin.x = arm_length / 2.0
 	if arm_col and arm_col.shape is BoxShape:
-		arm_col.shape = arm_col.shape.duplicate()
+		if not Engine.editor_hint or not arm_col.shape.resource_local_to_scene:
+			arm_col.shape = arm_col.shape.duplicate()
+			if Engine.editor_hint: arm_col.shape.resource_local_to_scene = true
 		arm_col.shape.extents.x = arm_length / 2.0
 		arm_col.transform.origin.x = arm_length / 2.0
 
 	var plat_mesh = _platform.get_node_or_null("MeshInstance")
 	var plat_col = _platform.get_node_or_null("CollisionShape")
 	if plat_mesh and plat_mesh.mesh is CubeMesh:
-		plat_mesh.mesh = plat_mesh.mesh.duplicate()
+		if not Engine.editor_hint or not plat_mesh.mesh.resource_local_to_scene:
+			plat_mesh.mesh = plat_mesh.mesh.duplicate()
+			if Engine.editor_hint: plat_mesh.mesh.resource_local_to_scene = true
 		plat_mesh.mesh.size.x = arm_length
 		plat_mesh.transform.origin.x = arm_length / 2.0
 	if plat_col and plat_col.shape is BoxShape:
-		plat_col.shape = plat_col.shape.duplicate()
+		if not Engine.editor_hint or not plat_col.shape.resource_local_to_scene:
+			plat_col.shape = plat_col.shape.duplicate()
+			if Engine.editor_hint: plat_col.shape.resource_local_to_scene = true
 		plat_col.shape.extents.x = arm_length / 2.0
 		plat_col.transform.origin.x = arm_length / 2.0
 

--- a/core_v2/props/RetractableBridge.gd
+++ b/core_v2/props/RetractableBridge.gd
@@ -1,144 +1,179 @@
-extends InteractableBaseV2
-class_name RetractableBridge
 tool
+extends Spatial
+class_name RetractableBridge
 
-# RetractableBridge.gd - Mechanical bridge with two-phase animation.
-# Inherits from InteractableBaseV2 for deterministic animation state.
+signal extended()
+signal retracted()
+signal extend_progress(ratio)
+signal retract_progress(ratio)
 
-export(bool) var starts_extended := false setget set_starts_extended
-export(float) var extend_duration := 1.5 setget set_extend_duration
-export(float, 2.0, 30.0) var bridge_length := 8.0 setget set_bridge_length
-export(float, 2.0, 10.0) var bridge_width := 3.0 setget set_bridge_width
+export(String, "left", "right") var side: String = "left" setget set_side
+export(float) var arm_length: float = 4.0 setget set_arm_length
+export(Vector2) var pivot_offset: Vector2 = Vector2.ZERO setget set_pivot_offset
+export(int) var extend_steps: int = 30
+export(int) var retract_steps: int = 20
 
-# Alias for compatibility with Batch 3 spec
-var extended: bool setget set_extended, get_extended
+var _is_extended: bool = false
+var _is_moving: bool = false
+var _target_extended: bool = false
+var _current_step: int = 0
+var _step_timer: float = 0.0
+# Target ~15s total for 30 steps as per user's prompt (30 steps * ~0.5s per step?)
+# Wait, user said: "30 pasos * ~0.016s = ~0.5s por step, total ~15s para extension completa"
+# 30 * 0.016 is 0.48s total.
+# "total ~15s para extension completa" suggests each step is 0.5s.
+# 30 steps * 0.5s = 15s.
+# 0.5s is roughly 30 frames at 60fps.
+# I will use a configurable step duration, or just follow the "total 15s" hint.
+# Let's assume step_duration = 0.5s.
+var _step_duration: float = 0.5
 
-onready var _arm_front: Spatial = get_node_or_null("ArmFront")
-onready var _arm_back: Spatial = get_node_or_null("ArmBack")
-onready var _platform: Spatial = get_node_or_null("Platform")
-onready var _deck_mesh_node: MeshInstance = get_node_or_null("Platform/DeckMesh")
-onready var _collision_node: CollisionShape = get_node_or_null("Platform/StaticBody/CollisionShape")
-onready var _rail_left: MeshInstance = get_node_or_null("RailLeft")
-onready var _rail_right: MeshInstance = get_node_or_null("RailRight")
+onready var _base: StaticBody = get_node_or_null("Base")
+onready var _arm: AnimatableBody = get_node_or_null("Base/Arm")
+onready var _platform: AnimatableBody = get_node_or_null("Base/Arm/Platform")
 
 func _ready():
-	# Sync initial settings
-	anim_duration = extend_duration
-	starts_active = starts_extended
-	._ready()
-	_rebuild()
+	_update_layout()
+	if not Engine.editor_hint:
+		set_physics_process(true)
 
-func set_starts_extended(v: bool):
-	starts_extended = v
-	starts_active = v
+func _physics_process(delta: float):
+	if Engine.editor_hint:
+		return
 
-func set_extend_duration(v: float):
-	extend_duration = v
-	anim_duration = v
+	if _is_moving:
+		_step_timer += delta
+		if _step_timer >= _step_duration:
+			_step_timer = 0.0
+			_execute_step()
 
-func set_extended(v: bool):
-	set_active(v)
+func _execute_step():
+	_current_step += 1
+	var total_steps = extend_steps if _target_extended else retract_steps
+	var ratio = float(_current_step) / float(total_steps)
 
-func get_extended() -> bool:
-	return is_active
+	if _target_extended:
+		# Extension: Arm rotates 0->90, Platform slides 0->arm_length in parallel
+		_update_transforms(ratio)
+		emit_signal("extend_progress", ratio)
+		if _current_step >= extend_steps:
+			_is_moving = false
+			_is_extended = true
+			emit_signal("extended")
+	else:
+		# Retraction: Platform retracts first, then arm.
+		# Prompt says: "Al llamar a retract(), se invierte: primero la plataforma se repliega completamente, luego el brazo vuelve a 0 grados."
+		# This means it's NOT parallel for retraction.
+		# Total retraction steps will be split.
+		var half_steps = total_steps / 2
+		if _current_step <= half_steps:
+			# Phase 1: Platform retracts
+			var p_ratio = 1.0 - (float(_current_step) / float(half_steps))
+			_update_platform(p_ratio)
+		else:
+			# Phase 2: Arm rotates back
+			var a_ratio = 1.0 - (float(_current_step - half_steps) / float(total_steps - half_steps))
+			_update_arm(a_ratio)
 
-func set_bridge_length(v: float):
-	bridge_length = v
-	_rebuild()
+		emit_signal("retract_progress", ratio)
+		if _current_step >= total_steps:
+			_is_moving = false
+			_is_extended = false
+			emit_signal("retracted")
 
-func set_bridge_width(v: float):
-	bridge_width = v
-	_rebuild()
+func _update_transforms(ratio: float):
+	_update_arm(ratio)
+	_update_platform(ratio)
 
-func _rebuild():
-	if not is_inside_tree(): return
+func _update_arm(ratio: float):
+	if not _arm: return
+	var angle = deg2rad(ratio * 90.0)
+	# Side affects axis direction.
+	# If side is left, pivot on left, rotates down/out.
+	# User: "Z positivo para left, Z negativo para right"
+	var z_sign = 1.0 if side == "left" else -1.0
+	_arm.rotation.z = angle * z_sign
 
-	var half_l = bridge_length * 0.5
-	var half_w = bridge_width * 0.5
-
-	# Arms at the ends, transverse
-	if _arm_front: _arm_front.translation = Vector3(0, 0, -half_l)
-	if _arm_back: _arm_back.translation = Vector3(0, 0, half_l)
-
-	if _arm_front and _arm_front.has_node("ArmMesh"):
-		var am = _arm_front.get_node("ArmMesh") as MeshInstance
-		if am.mesh is CylinderMesh:
-			if not am.mesh.resource_local_to_scene:
-				am.mesh = am.mesh.duplicate()
-			(am.mesh as CylinderMesh).height = bridge_width
-		am.translation = Vector3(0, half_w, 0)
-		am.rotation_degrees = Vector3(0, 0, 90)
-
-	if _arm_back and _arm_back.has_node("ArmMesh"):
-		var am = _arm_back.get_node("ArmMesh") as MeshInstance
-		if am.mesh is CylinderMesh:
-			if not am.mesh.resource_local_to_scene:
-				am.mesh = am.mesh.duplicate()
-			(am.mesh as CylinderMesh).height = bridge_width
-		am.translation = Vector3(0, half_w, 0)
-		am.rotation_degrees = Vector3(0, 0, 90)
-
-	if _deck_mesh_node and _deck_mesh_node.mesh is CubeMesh:
-		if not _deck_mesh_node.mesh.resource_local_to_scene:
-			_deck_mesh_node.mesh = _deck_mesh_node.mesh.duplicate()
-		(_deck_mesh_node.mesh as CubeMesh).size = Vector3(bridge_width, 0.2, bridge_length)
-
-	if _collision_node and _collision_node.shape is BoxShape:
-		if not _collision_node.shape.resource_local_to_scene:
-			_collision_node.shape = _collision_node.shape.duplicate()
-		(_collision_node.shape as BoxShape).extents = Vector3(half_w, 0.1, half_l)
-
-	if _rail_left:
-		_rail_left.translation = Vector3(-half_w, 0.1, 0)
-		if _rail_left.mesh is CubeMesh:
-			if not _rail_left.mesh.resource_local_to_scene:
-				_rail_left.mesh = _rail_left.mesh.duplicate()
-			(_rail_left.mesh as CubeMesh).size = Vector3(0.1, 0.1, bridge_length)
-	if _rail_right:
-		_rail_right.translation = Vector3(half_w, 0.1, 0)
-		if _rail_right.mesh is CubeMesh:
-			if not _rail_right.mesh.resource_local_to_scene:
-				_rail_right.mesh = _rail_right.mesh.duplicate()
-			(_rail_right.mesh as CubeMesh).size = Vector3(0.1, 0.1, bridge_length)
-
-	_update_visuals()
-
-func _update_visuals():
-	if not _arm_front or not _platform: return
-
-	# Phase 1: Arms (0.0 - 0.4)
-	var t_arms = clamp(anim_progress / 0.4, 0.0, 1.0)
-	var eased_arms = _ease_out(t_arms)
-	var arm_rot_offset = lerp(0.0, 90.0, eased_arms)
-
-	_arm_front.rotation_degrees.z = -arm_rot_offset
-	_arm_back.rotation_degrees.z = arm_rot_offset
-
-	# Phase 2: Platform (0.4 - 1.0)
-	var t_platform = clamp((anim_progress - 0.4) / 0.6, 0.0, 1.0)
-	var eased_platform = _ease_in_out(t_platform)
-
-	_platform.translation.z = lerp(-bridge_length, 0.0, eased_platform)
-	_platform.visible = (anim_progress > 0.35)
-
-	if _collision_node:
-		_collision_node.disabled = anim_progress < 0.95
-
-func toggle():
-	interact()
+func _update_platform(ratio: float):
+	if not _platform: return
+	# Platform slides along the arm. Assume arm X axis is the extension direction.
+	_platform.transform.origin.x = ratio * arm_length
 
 func extend():
-	set_active(true)
+	if _is_extended or (_is_moving and _target_extended):
+		return
+	_target_extended = true
+	_is_moving = true
+	_current_step = 0
+	_step_timer = _step_duration # Start first step immediately or after one duration?
+	# User says "cada step debe interpolar". I'll start at 0.
 
 func retract():
-	set_active(false)
+	if not _is_extended or (_is_moving and not _target_extended):
+		return
+	_target_extended = false
+	_is_moving = true
+	_current_step = 0
+	_step_timer = _step_duration
 
-func _on_animation_completed():
-	._on_animation_completed()
-	if anim_progress >= 1.0:
-		emit_signal("bridge_extended")
-	elif anim_progress <= 0.0:
-		emit_signal("bridge_retracted")
+func set_side(v):
+	side = v
+	if Engine.editor_hint: _update_layout()
 
-signal bridge_extended()
-signal bridge_retracted()
+func set_arm_length(v):
+	arm_length = v
+	if Engine.editor_hint: _update_layout()
+
+func set_pivot_offset(v):
+	pivot_offset = v
+	if Engine.editor_hint: _update_layout()
+
+func _update_layout():
+	_base = get_node_or_null("Base")
+	_arm = get_node_or_null("Base/Arm")
+	_platform = get_node_or_null("Base/Arm/Platform")
+
+	if not _base or not _arm or not _platform:
+		return
+
+	# Calculate pivot from edge of base
+	# Assuming Base is a cube at origin with some size.
+	# Let's assume base size is (2, 1, 2) for reference, but we should probably
+	# use the Mesh size if available, or just define it.
+	var base_mesh = _base.get_node_or_null("MeshInstance")
+	var base_half_width = 1.0
+	if base_mesh and base_mesh.mesh is CubeMesh:
+		base_half_width = base_mesh.mesh.size.x / 2.0
+
+	var pivot_x = -base_half_width if side == "left" else base_half_width
+	_arm.transform.origin = Vector3(pivot_x + pivot_offset.x, 0, pivot_offset.y)
+
+	# Update visual scales and offsets based on arm_length
+	var arm_mesh = _arm.get_node_or_null("MeshInstance")
+	var arm_col = _arm.get_node_or_null("CollisionShape")
+	if arm_mesh and arm_mesh.mesh is CubeMesh:
+		arm_mesh.mesh = arm_mesh.mesh.duplicate()
+		arm_mesh.mesh.size.x = arm_length
+		arm_mesh.transform.origin.x = arm_length / 2.0
+	if arm_col and arm_col.shape is BoxShape:
+		arm_col.shape = arm_col.shape.duplicate()
+		arm_col.shape.extents.x = arm_length / 2.0
+		arm_col.transform.origin.x = arm_length / 2.0
+
+	var plat_mesh = _platform.get_node_or_null("MeshInstance")
+	var plat_col = _platform.get_node_or_null("CollisionShape")
+	if plat_mesh and plat_mesh.mesh is CubeMesh:
+		plat_mesh.mesh = plat_mesh.mesh.duplicate()
+		plat_mesh.mesh.size.x = arm_length
+		plat_mesh.transform.origin.x = arm_length / 2.0
+	if plat_col and plat_col.shape is BoxShape:
+		plat_col.shape = plat_col.shape.duplicate()
+		plat_col.shape.extents.x = arm_length / 2.0
+		plat_col.transform.origin.x = arm_length / 2.0
+
+	if not _is_moving:
+		_update_transforms(1.0 if _is_extended else 0.0)
+
+func interact():
+	if _is_extended: retract()
+	else: extend()

--- a/core_v2/props/RetractableBridge.tscn
+++ b/core_v2/props/RetractableBridge.tscn
@@ -2,66 +2,53 @@
 
 [ext_resource path="res://core_v2/props/RetractableBridge.gd" type="Script" id=1]
 
-[sub_resource type="CylinderMesh" id=1]
-top_radius = 0.1
-bottom_radius = 0.1
-height = 3.0
+[sub_resource type="CubeMesh" id=1]
+size = Vector3( 2, 0.5, 2 )
 
-[sub_resource type="SpatialMaterial" id=2]
-albedo_color = Color( 0.2, 0.2, 0.22, 1 )
-metallic = 0.5
-roughness = 0.3
+[sub_resource type="BoxShape" id=2]
+extents = Vector3( 1, 0.25, 1 )
 
 [sub_resource type="CubeMesh" id=3]
-size = Vector3( 3, 0.2, 8 )
+size = Vector3( 4, 0.2, 0.8 )
 
-[sub_resource type="SpatialMaterial" id=4]
-albedo_color = Color( 0.3, 0.3, 0.35, 1 )
-metallic = 0.6
-roughness = 0.5
+[sub_resource type="BoxShape" id=4]
+extents = Vector3( 2, 0.1, 0.4 )
 
-[sub_resource type="BoxShape" id=5]
-extents = Vector3( 1.5, 0.1, 4 )
+[sub_resource type="CubeMesh" id=5]
+size = Vector3( 4, 0.1, 1 )
 
-[sub_resource type="CubeMesh" id=6]
-size = Vector3( 0.1, 0.1, 8 )
+[sub_resource type="BoxShape" id=6]
+extents = Vector3( 2, 0.05, 0.5 )
 
 [node name="RetractableBridge" type="Spatial"]
 script = ExtResource( 1 )
 
-[node name="ArmFront" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -4 )
+[node name="Base" type="StaticBody" parent="."]
 
-[node name="ArmMesh" type="MeshInstance" parent="ArmFront"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 1.5, 1.5, 0 )
+[node name="MeshInstance" type="MeshInstance" parent="Base"]
 mesh = SubResource( 1 )
-material/0 = SubResource( 2 )
 
-[node name="ArmBack" type="Spatial" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4 )
+[node name="CollisionShape" type="CollisionShape" parent="Base"]
+shape = SubResource( 2 )
 
-[node name="ArmMesh" type="MeshInstance" parent="ArmBack"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -1.5, 1.5, 0 )
-mesh = SubResource( 1 )
-material/0 = SubResource( 2 )
+[node name="Arm" type="AnimatableBody" parent="Base"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 0, 0 )
 
-[node name="Platform" type="Spatial" parent="."]
-
-[node name="DeckMesh" type="MeshInstance" parent="Platform"]
+[node name="MeshInstance" type="MeshInstance" parent="Base/Arm"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, -0.1, 0 )
 mesh = SubResource( 3 )
-material/0 = SubResource( 4 )
 
-[node name="StaticBody" type="StaticBody" parent="Platform"]
+[node name="CollisionShape" type="CollisionShape" parent="Base/Arm"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, -0.1, 0 )
+shape = SubResource( 4 )
 
-[node name="CollisionShape" type="CollisionShape" parent="Platform/StaticBody"]
-shape = SubResource( 5 )
+[node name="Platform" type="AnimatableBody" parent="Base/Arm"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0 )
 
-[node name="RailLeft" type="MeshInstance" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -1.5, 0.1, 0 )
-mesh = SubResource( 6 )
-material/0 = SubResource( 2 )
+[node name="MeshInstance" type="MeshInstance" parent="Base/Arm/Platform"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, 0 )
+mesh = SubResource( 5 )
 
-[node name="RailRight" type="MeshInstance" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 1.5, 0.1, 0 )
-mesh = SubResource( 6 )
-material/0 = SubResource( 2 )
+[node name="CollisionShape" type="CollisionShape" parent="Base/Arm/Platform"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, 0 )
+shape = SubResource( 6 )


### PR DESCRIPTION
This PR introduces two new interactive props: FireEmitter and RetractableBridge.

FireEmitter:
- Inherits from Area.
- Emits damage_tick(damage) every 0.5s while the player is inside.
- Features a procedural ParticlesMaterial (PointMesh) with orange/red colors and smoke.
- Includes an extinguish() method to stop the fire and disable damage.

RetractableBridge:
- Inherits from Spatial.
- Features a StaticBody base, an AnimatableBody arm, and an AnimatableBody platform.
- Implements a manual step system in _physics_process for deterministic movement.
- Handles complex retraction logic (platform first, then arm).
- Configurable via the inspector (side, length, steps, etc.) and updates visuals in tool mode.

---
*PR created automatically by Jules for task [17347786418387309978](https://jules.google.com/task/17347786418387309978) started by @icarito*