### PR TITLE
fix: deterministic pickup/release in CargolDroneV2 (issues #200 #201)

### DIFF
--- a/core_v2/actors/CargolDroneV2.gd
+++ b/core_v2/actors/CargolDroneV2.gd
@@ -35,6 +35,7 @@ var _is_following_target := false
 # Deterministic input buffer from agents
 var _intended_velocity := Vector3.ZERO
 var _has_intended_velocity := false
+var _canonical_velocity := Vector3.ZERO # Velocity snapshot before move_and_slide()
 
 # Parenting Logic State
 var _original_parent_path := ""
@@ -50,14 +51,16 @@ func _init():
 	add_to_group("cargol_drone")
 
 func _ready():
-	if has_node("CargoAnchor"):
-		cargo_anchor = get_node("CargoAnchor")
+	# CargoAnchor must live outside the KinematicBody so cargo inherits the
+	# canonical logical transform, not an interpolated visual one.
+	var anchor = Position3D.new()
+	anchor.name = "CargoAnchor"
+	var parent_node = get_parent()
+	if parent_node:
+		parent_node.add_child(anchor)
 	else:
-		# Create anchor if not present in scene (fallback)
-		var anchor = Position3D.new()
-		anchor.name = "CargoAnchor"
-		add_child(anchor)
-		cargo_anchor = anchor
+		add_child(anchor) # fallback for tests / headless scenes
+	cargo_anchor = anchor
 
 	# Register as OYS Actor
 	var sm = get_node_or_null("/root/SessionManager")
@@ -211,8 +214,8 @@ func release(impulse: Vector3) -> void:
 			target.linear_velocity = Vector3.ZERO
 			target.angular_velocity = Vector3.ZERO
 			
-			# Apply drone velocity + throw impulse
-			target.apply_central_impulse(impulse + velocity)
+			# Use canonical velocity (pre-move_and_slide) for deterministic throw momentum.
+			target.apply_central_impulse(impulse + _canonical_velocity)
 
 		print("[Cargol] Released: ", target.name)
 
@@ -326,8 +329,16 @@ func step(dt: float) -> void:
 
 	if _perf_monitor and _perf_monitor.has_method("measure_end"):
 		_perf_monitor.measure_end(self, "step")
-	
+
+	# Capture canonical velocity BEFORE move_and_slide() can alter it via collision response.
+	# release() uses this so thrown cargo momentum is deterministic across runs.
+	_canonical_velocity = velocity
+
 	_apply_movement_and_rotation()
+
+	# Keep anchor in sync with the logical (canonical) transform, not the visual one.
+	if cargo_anchor and cargo_anchor.get_parent() != self:
+		cargo_anchor.global_transform = global_transform
 
 
 func _apply_movement_and_rotation() -> void:

--- a/core_v2/tests/test_cargol_determinism.gd
+++ b/core_v2/tests/test_cargol_determinism.gd
@@ -1,0 +1,78 @@
+extends GdUnitTestSuite
+
+# Tests for CargolDroneV2 determinism fixes (issues #200 and #201).
+#
+# Bug #1: CargoAnchor was a child of the KinematicBody. Now it must be a
+#         sibling (child of the drone's parent) so cargo inherits the
+#         canonical logical transform, not an interpolated visual one.
+#
+# Bug #2: release() was using `velocity` after move_and_slide() had altered
+#         it via collision response. Now `_canonical_velocity` captures the
+#         intent before that mutation.
+
+func test_cargo_anchor_is_sibling_not_child() -> void:
+	var runner := scene_runner("res://core_v2/tests/TestScene_Cargol.tscn")
+	yield(runner.simulate_frames(3), "completed")
+
+	var drone = runner.scene().find_node("CargolDrone", true, false)
+	assert_object(drone).is_not_null()
+
+	var anchor = drone.cargo_anchor
+	assert_object(anchor).is_not_null()
+
+	# Fix #1: anchor must NOT be a child of the drone itself.
+	assert_bool(anchor.get_parent() == drone).is_false()
+	# It should be a child of whatever contains the drone.
+	assert_object(anchor.get_parent()).is_equal(drone.get_parent())
+
+func test_canonical_velocity_set_after_step() -> void:
+	var runner := scene_runner("res://core_v2/tests/TestScene_Cargol.tscn")
+	yield(runner.simulate_frames(3), "completed")
+
+	var drone = runner.scene().find_node("CargolDrone", true, false)
+	assert_object(drone).is_not_null()
+
+	# _canonical_velocity starts at zero before any movement.
+	assert_bool(drone._canonical_velocity == Vector3.ZERO).is_true()
+
+	# Give the drone an intended velocity and run several frames.
+	drone.set_velocity(Vector3(5.0, 0.0, 0.0))
+	yield(runner.simulate_frames(10), "completed")
+
+	# Fix #2: after acceleration, _canonical_velocity must be non-zero,
+	# confirming it is captured each step before move_and_slide() can alter it.
+	assert_bool(drone._canonical_velocity == Vector3.ZERO).is_false()
+
+func test_release_uses_canonical_not_post_slide_velocity() -> void:
+	# Verify that after pickup + manual step manipulation, the impulse applied
+	# on release matches _canonical_velocity (not the post-slide `velocity`).
+	var runner := scene_runner("res://core_v2/tests/TestScene_Cargol.tscn")
+	yield(runner.simulate_frames(3), "completed")
+
+	var drone = runner.scene().find_node("CargolDrone", true, false)
+	assert_object(drone).is_not_null()
+
+	# Manually force a known canonical velocity state.
+	drone._canonical_velocity = Vector3(3.0, 0.0, 0.0)
+	# Make post-slide velocity deliberately different to prove release does NOT use it.
+	drone.velocity = Vector3(99.0, 0.0, 0.0)
+
+	var cargo = runner.scene().find_node("Cargo", true, false)
+	if cargo:
+		drone.pickup("Cargo")
+		yield(runner.simulate_frames(2), "completed")
+
+		# Track pre-release linear_velocity (zero after kinematic pickup).
+		assert_bool(cargo.linear_velocity == Vector3.ZERO).is_true()
+
+		# Release with zero impulse; only _canonical_velocity contributes.
+		drone.release(Vector3.ZERO)
+		yield(runner.simulate_frames(2), "completed")
+
+		# Cargo impulse = impulse(0) + _canonical_velocity(3,0,0).
+		# Post-slide velocity(99,0,0) must NOT have been used.
+		# We can't inspect apply_central_impulse directly, but we can confirm
+		# the magnitude is consistent with 3 m/s, not 99 m/s.
+		var speed = cargo.linear_velocity.length()
+		# Allow physics tolerance; just rule out the 99 m/s case.
+		assert_bool(speed < 50.0).is_true()


### PR DESCRIPTION
Bug #1 (pickup): CargoAnchor is now created as a child of the drone's
parent instead of the KinematicBody itself. This ensures cargo attached
during pickup inherits the canonical logical transform rather than any
interpolated visual transform. The anchor is kept in sync via
global_transform each step().

Bug #2 (release): Introduced _canonical_velocity, captured immediately
before _apply_movement_and_rotation() calls move_and_slide(). release()
now uses _canonical_velocity instead of the post-slide velocity, making
thrown-cargo momentum identical across replays regardless of per-frame
collision variance.

Adds test_cargol_determinism.gd (GdUnit) covering: anchor sibling
placement, canonical velocity capture, and release impulse magnitude.

https://claude.ai/code/session_01Wfc62NjiszEuUhKccGvHTU