### PR TITLE
fix: CargoAnchor zombie en test — reusa nodo de escena en vez de duplicar

### DIFF
--- a/core_v2/actors/CargolDroneV2.gd
+++ b/core_v2/actors/CargolDroneV2.gd
@@ -53,14 +53,20 @@ func _init():
 func _ready():
 	# CargoAnchor must live outside the KinematicBody so cargo inherits the
 	# canonical logical transform, not an interpolated visual one.
-	var anchor = Position3D.new()
-	anchor.name = "CargoAnchor"
 	var parent_node = get_parent()
-	if parent_node:
-		parent_node.add_child(anchor)
+	
+	# Reuse existing anchor from scene if present, otherwise create one.
+	if has_node("CargoAnchor"):
+		cargo_anchor = get_node("CargoAnchor")
+		remove_child(cargo_anchor)
 	else:
-		add_child(anchor) # fallback for tests / headless scenes
-	cargo_anchor = anchor
+		cargo_anchor = Position3D.new()
+		cargo_anchor.name = "CargoAnchor"
+	
+	if parent_node:
+		parent_node.add_child(cargo_anchor)
+	else:
+		add_child(cargo_anchor)  # fallback for headless / tests
 
 	# Register as OYS Actor
 	var sm = get_node_or_null("/root/SessionManager")

--- a/core_v2/actors/CargolDroneV2.tscn
+++ b/core_v2/actors/CargolDroneV2.tscn
@@ -17,6 +17,3 @@ shape = SubResource( 1 )
 
 [node name="MeshInstance" type="MeshInstance" parent="."]
 mesh = SubResource( 2 )
-
-[node name="CargoAnchor" type="Position3D" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.6, 0 )


### PR DESCRIPTION
El test test_cargo_anchor_is_sibling_not_child fallaba en CI porque:\n\n1. CargolDroneV2.tscn ya tenia un nodo CargoAnchor estatico\n2. El fix de #208 creaba uno NUEVO en _ready() sin eliminar el original\n3. El nodo original quedaba zombie/huerfano en el scene tree\n4. CI detectaba el huerfano y el test fallaba\n\nFix:\n- _ready() ahora reusa el CargoAnchor si existe (remove_child + reparent)\n- Si no existe, lo crea como antes\n- Eliminado el nodo CargoAnchor estatico del .tscn\n\nFixes CI: Odyssey Pytest Runner