### PR TITLE
FD-030 Cargol: Implementation of Tasks A and B

### DIFF
--- a/core_v2/actors/CargolDroneV2.tscn
+++ b/core_v2/actors/CargolDroneV2.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://core_v2/actors/CargolDroneV2.gd" type="Script" id=1]
+[ext_resource path="res://core_v2/actors/CargolPlayerInput.gd" type="Script" id=2]
 
 [sub_resource type="SphereShape" id=1]
 radius = 0.5
@@ -20,3 +21,6 @@ mesh = SubResource( 2 )
 
 [node name="CargoAnchor" type="Position3D" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.6, 0 )
+
+[node name="CargolPlayerInput" type="Node" parent="."]
+script = ExtResource( 2 )

--- a/core_v2/actors/CargolPlayerInput.gd
+++ b/core_v2/actors/CargolPlayerInput.gd
@@ -1,0 +1,83 @@
+extends Node
+
+# CargolPlayerInput.gd - Command layer for CargolDroneV2
+
+onready var drone = get_parent()
+
+var _is_c_held := false
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("cargol_command"):
+		_is_c_held = true
+	elif event.is_action_released("cargol_command"):
+		if _is_c_held:
+			_on_c_tapped()
+		_is_c_held = false
+
+	if _is_c_held and event.is_action_pressed("interact"):
+		_on_c_plus_e()
+		# Prevent tap on release
+		_is_c_held = false
+		get_tree().set_input_as_handled()
+
+func _on_c_tapped() -> void:
+	var target_pos = _get_raycast_target()
+	if target_pos != Vector3.ZERO:
+		drone.move_to(target_pos)
+	else:
+		_toggle_follow()
+
+func _on_c_plus_e() -> void:
+	var cargo_info = drone.query_cargo()
+	if cargo_info.get("attached", false):
+		drone.release(Vector3.ZERO)
+	else:
+		var nearest_box = _find_nearest_in_group("pushable_box", 5.0)
+		if nearest_box:
+			drone.pickup(nearest_box.get_path())
+
+func _get_raycast_target() -> Vector3:
+	var camera = get_viewport().get_camera()
+	if not camera: return Vector3.ZERO
+
+	var viewport_size = get_viewport().size
+	var viewport_center = viewport_size / 2.0
+
+	var from = camera.project_ray_origin(viewport_center)
+	var to = from + camera.project_ray_normal(viewport_center) * 100.0
+
+	var space_state = drone.get_world().direct_space_state
+	# Collide with environment (layer 1)
+	var result = space_state.intersect_ray(from, to, [drone], 1)
+
+	if result:
+		return result.position
+	return Vector3.ZERO
+
+func _toggle_follow() -> void:
+	if drone.get("_is_following_target"):
+		drone.stop()
+	else:
+		var player = _find_player()
+		if player:
+			drone.follow_target(player)
+
+func _find_player() -> Node:
+	var players = get_tree().get_nodes_in_group("player")
+	if players.size() > 0:
+		return players[0]
+	return null
+
+func _find_nearest_in_group(group_name: String, max_dist: float) -> Spatial:
+	var nodes = get_tree().get_nodes_in_group(group_name)
+	var nearest = null
+	var min_dist = max_dist
+	var my_pos = drone.global_transform.origin
+
+	for node in nodes:
+		if node is Spatial:
+			var dist = my_pos.distance_to(node.global_transform.origin)
+			if dist < min_dist:
+				min_dist = dist
+				nearest = node
+	return nearest

--- a/core_v2/components/ui/InteractionMarker.gd
+++ b/core_v2/components/ui/InteractionMarker.gd
@@ -62,6 +62,49 @@ func unregister(interactable: Spatial) -> void:
 			_entries.remove(i)
 			return
 
+func get_targets_in_range(origin: Vector3, p_range: float) -> Array:
+	var results = []
+	for entry in _entries:
+		if not is_instance_valid(entry.interactable):
+			continue
+		var pos = entry.interactable.global_transform.origin
+		var dist = origin.distance_to(pos)
+		if dist <= p_range:
+			results.append({
+				"spatial": entry.interactable,
+				"config": entry.config,
+				"distance": dist,
+				"state": entry.state,
+				"priority": entry.priority
+			})
+
+	results.sort_custom(self, "_sort_targets")
+
+	# Strip internal priority from final dictionaries to match spec
+	var final_results = []
+	for res in results:
+		final_results.append({
+			"spatial": res.spatial,
+			"config": res.config,
+			"distance": res.distance,
+			"state": res.state
+		})
+	return final_results
+
+func _sort_targets(a, b) -> bool:
+	if a.priority != b.priority:
+		return a.priority < b.priority
+	return a.distance < b.distance
+
+func get_named_target(p_label: String) -> Spatial:
+	for entry in _entries:
+		if is_instance_valid(entry.interactable) and entry.config.label == p_label:
+			return entry.interactable
+	return null
+
+func get_registered_count() -> int:
+	return _entries.size()
+
 func update_config(interactable: Spatial, config: Resource) -> void:
 	register(interactable, config)
 

--- a/core_v2/tests/test_cargol_determinism.gd
+++ b/core_v2/tests/test_cargol_determinism.gd
@@ -76,3 +76,12 @@ func test_release_uses_canonical_not_post_slide_velocity() -> void:
 		var speed = cargo.linear_velocity.length()
 		# Allow physics tolerance; just rule out the 99 m/s case.
 		assert_bool(speed < 50.0).is_true()
+
+func test_cargol_player_input_exists() -> void:
+	var drone_scene = load("res://core_v2/actors/CargolDroneV2.tscn")
+	var drone = auto_free(drone_scene.instance())
+	add_child(drone)
+
+	var input_node = drone.get_node_or_null("CargolPlayerInput")
+	assert_object(input_node).is_not_null()
+	assert_object(input_node.drone).is_equal(drone)

--- a/core_v2/tests/test_interaction_marker.gd
+++ b/core_v2/tests/test_interaction_marker.gd
@@ -112,3 +112,85 @@ func test_off_screen_arc_direction() -> void:
 	# Verify that the screen position of the off-screen object is to the right of the center
 	var vs = get_viewport().size
 	assert_bool(arc_data[0].pos.x > vs.x / 2.0).is_true()
+
+func test_get_targets_in_range() -> void:
+	var marker_scene = load("res://core_v2/components/ui/InteractionMarker.tscn")
+	var marker_system = auto_free(marker_scene.instance())
+	add_child(marker_system)
+
+	var objects = []
+	var distances = [3, 6, 9]
+	for i in range(3):
+		var spatial = auto_free(Spatial.new())
+		add_child(spatial)
+		spatial.translation = Vector3(distances[i], 0, 0)
+
+		var config = MarkerConfig.new()
+		config.label = "Obj %d" % i
+		config.interaction_range = 10.0
+
+		marker_system.register(spatial, config)
+		objects.append(spatial)
+
+	var targets = marker_system.get_targets_in_range(Vector3.ZERO, 5.0)
+	assert_int(targets.size()).is_equal(1)
+	assert_object(targets[0].spatial).is_equal(objects[0])
+
+	targets = marker_system.get_targets_in_range(Vector3.ZERO, 7.0)
+	assert_int(targets.size()).is_equal(2)
+	assert_object(targets[0].spatial).is_equal(objects[0])
+	assert_object(targets[1].spatial).is_equal(objects[1])
+
+func test_get_named_target() -> void:
+	var marker_scene = load("res://core_v2/components/ui/InteractionMarker.tscn")
+	var marker_system = auto_free(marker_scene.instance())
+	add_child(marker_system)
+
+	var spatial = auto_free(Spatial.new())
+	add_child(spatial)
+	var config = MarkerConfig.new()
+	config.label = "Consola OD-02"
+	marker_system.register(spatial, config)
+
+	var target = marker_system.get_named_target("Consola OD-02")
+	assert_object(target).is_equal(spatial)
+
+	target = marker_system.get_named_target("NonExistent")
+	assert_object(target).is_null()
+
+func test_get_targets_respects_priority_order() -> void:
+	var marker_scene = load("res://core_v2/components/ui/InteractionMarker.tscn")
+	var marker_system = auto_free(marker_scene.instance())
+	add_child(marker_system)
+
+	var priorities = [5, 1, 3]
+	for i in range(3):
+		var spatial = auto_free(Spatial.new())
+		add_child(spatial)
+		spatial.translation = Vector3(5, 0, 0) # Same distance
+
+		var config = MarkerConfig.new()
+		config.label = "Obj %d" % i
+		config.priority = priorities[i]
+
+		marker_system.register(spatial, config)
+
+	var targets = marker_system.get_targets_in_range(Vector3.ZERO, 10.0)
+	assert_int(targets.size()).is_equal(3)
+	assert_int(targets[0].config.priority).is_equal(1)
+	assert_int(targets[1].config.priority).is_equal(3)
+	assert_int(targets[2].config.priority).is_equal(5)
+
+func test_get_registered_count() -> void:
+	var marker_scene = load("res://core_v2/components/ui/InteractionMarker.tscn")
+	var marker_system = auto_free(marker_scene.instance())
+	add_child(marker_system)
+
+	assert_int(marker_system.get_registered_count()).is_equal(0)
+
+	var spatial = auto_free(Spatial.new())
+	add_child(spatial)
+	var config = MarkerConfig.new()
+	marker_system.register(spatial, config)
+
+	assert_int(marker_system.get_registered_count()).is_equal(1)

--- a/project.godot
+++ b/project.godot
@@ -2484,6 +2484,11 @@ cycle_performance_profile={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777253,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
+cargol_command={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":67,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [input_devices]
 


### PR DESCRIPTION
This PR implements the requested tasks A and B for the FD-030 Cargol feature.

### Tarea A: TargetRegistry en InteractionMarker
- Added `get_targets_in_range(origin, p_range)`: Returns sorted interactables within range.
- Added `get_named_target(p_label)`: Returns an interactable by its label.
- Added `get_registered_count()`: Returns the number of registered interactables.
- Added unit tests in `test_interaction_marker.gd`.

### Tarea B: Capa de comando CargolPlayerInput
- Created `core_v2/actors/CargolPlayerInput.gd`:
    - Tap C: Move drone to raycasted position or toggle follow/stop.
    - Hold C + E: Pickup nearest box or release cargo.
- Registered `cargol_command` (C key, scancode 67) in `project.godot`.
- Added `CargolPlayerInput` node to `core_v2/actors/CargolDroneV2.tscn`.
- Added a test case in `test_cargol_determinism.gd` to verify node presence and linkage.

Verified with unit tests using `godot3-server`.

---
*PR created automatically by Jules for task [13382244400239115559](https://jules.google.com/task/13382244400239115559) started by @icarito*