### PR TITLE
FD-214: Runbin HTML5 — reproduce hotzones .bin desde URL en build web

### DIFF
--- a/core_v2/telemetry/html/odisea_shell.html
+++ b/core_v2/telemetry/html/odisea_shell.html
@@ -379,7 +379,8 @@ $GODOT_HEAD_INCLUDE
 					session_id: sessionId,
 					total_ms: Date.now() - loaderStartMs
 				});
-			}
+			},
+			pendingRunbin: null
 		};
 
 		// --- Popup (error / slow-load watchdog) ---
@@ -452,21 +453,50 @@ $GODOT_HEAD_INCLUDE
 			}, 600);
 		}
 
-		var engine = new Engine($GODOT_CONFIG);
-		engine.startGame({
-			onProgress: function(current, total) {
-				var t = (total > 0 && total >= current) ? total : EXPECTED_TOTAL_BYTES;
-				if (t > 0) {
-					barFillEl.style.width = Math.min(100, current / t * 100).toFixed(1) + "%";
+		var godotConfig = $GODOT_CONFIG;
+		var runbinUrl = new URLSearchParams(window.location.search).get("runbin");
+
+		async function startGodot() {
+			if (runbinUrl) {
+				loreEl.textContent = "Descargando captura de rendimiento...";
+				try {
+					var resp = await fetch(runbinUrl);
+					if (!resp.ok) throw new Error("HTTP " + resp.status);
+					var binBuf = await resp.arrayBuffer();
+					window.OdiseaShell.pendingRunbin = binBuf;
+					console.log("[Runbin] Downloaded " + binBuf.byteLength + " bytes");
+					loreEl.textContent = "Cargando captura en el motor...";
+					// Force HotzonePlayer scene
+					godotConfig.canvasResizePolicy = 1;
+					if (!godotConfig.args) godotConfig.args = [];
+					godotConfig.args.push("--main-loop", "res://core_v2/tools/HotzonePlayer.tscn");
+				} catch (err) {
+					clearInterval(loreTimer);
+					loreEl.textContent = "Error al descargar captura: " + err.message;
+					console.error("[Runbin] Download failed:", err);
+					showPopup(POPUP_ERROR_MSG);
+					return;
 				}
-			},
-			onComplete: onEngineStarted
-		}).then(onEngineStarted).catch(function(err) {
-			clearInterval(loreTimer);
-			loreEl.textContent = "Error al cargar. Recarga la página.";
-			console.error("[ODiSEA] Engine start failed:", err);
-			showPopup(POPUP_ERROR_MSG);
-		});
+			}
+
+			var engine = new Engine(godotConfig);
+			engine.startGame({
+				onProgress: function(current, total) {
+					var t = (total > 0 && total >= current) ? total : EXPECTED_TOTAL_BYTES;
+					if (t > 0) {
+						barFillEl.style.width = Math.min(100, current / t * 100).toFixed(1) + "%";
+					}
+				},
+				onComplete: onEngineStarted
+			}).then(onEngineStarted).catch(function(err) {
+				clearInterval(loreTimer);
+				loreEl.textContent = "Error al cargar. Recarga la página.";
+				console.error("[ODiSEA] Engine start failed:", err);
+				showPopup(POPUP_ERROR_MSG);
+			});
+		}
+
+		startGodot();
 	</script>
 </body>
 </html>

--- a/core_v2/tools/HotzonePlayer.gd
+++ b/core_v2/tools/HotzonePlayer.gd
@@ -33,22 +33,43 @@ var loaded_scene_node = null
 var scene_override := ""
 
 func _ready():
+	var replay_path = ""
+
+	# Web path: receive binary from JavaScript shared via OdiseaShell.pendingRunbin
+	if OS.has_feature("web"):
+		var js = JavaScript.get_interface("OdiseaShell")
+		if js != null and js.pendingRunbin != null:
+			var buf = js.pendingRunbin
+			replay_path = "user://hotzones/remote.bin"
+			var dir = Directory.new()
+			dir.make_dir_recursive("user://hotzones")
+			var f = File.new()
+			if f.open(replay_path, File.WRITE) == OK:
+				f.store_buffer(buf)
+				f.close()
+				print("[HotzonePlayer] Saved web binary to ", replay_path, " (", buf.size(), " bytes)")
+			else:
+				_show_error("Could not save web binary to user://")
+				return
+			# Clear so it doesn't persist on reload
+			js.pendingRunbin = null
+
 	# Parse command line: --replay-file (required), --replay-scene (override the
 	# scene baked in the .bin), --replay-speed (initial 1/2/4x playback speed).
-	var replay_path = ""
-	var args = OS.get_cmdline_args()
-	for i in range(args.size()):
-		if args[i] == "--replay-file" and i + 1 < args.size():
-			replay_path = args[i + 1]
-		elif args[i] == "--replay-scene" and i + 1 < args.size():
-			scene_override = args[i + 1]
-		elif args[i] == "--replay-speed" and i + 1 < args.size():
-			playback_speed = max(1.0, float(args[i + 1]))
-		elif args[i] == "--replay-warmup" and i + 1 < args.size():
-			warmup_sec = max(0.0, float(args[i + 1]))
+	if replay_path == "":
+		var args = OS.get_cmdline_args()
+		for i in range(args.size()):
+			if args[i] == "--replay-file" and i + 1 < args.size():
+				replay_path = args[i + 1]
+			elif args[i] == "--replay-scene" and i + 1 < args.size():
+				scene_override = args[i + 1]
+			elif args[i] == "--replay-speed" and i + 1 < args.size():
+				playback_speed = max(1.0, float(args[i + 1]))
+			elif args[i] == "--replay-warmup" and i + 1 < args.size():
+				warmup_sec = max(0.0, float(args[i + 1]))
 
 	if replay_path == "":
-		_show_error("No replay file specified. Use --replay-file <path>")
+		_show_error("No replay file specified.")
 		return
 
 	if not _load_binary(replay_path):

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -27,7 +27,7 @@ import { PlayerFocus } from './components/PlayerFocus';
 import { PlayerTagEditor } from './components/PlayerTagEditor';
 import { useTelemetry } from './hooks/useTelemetry';
 import { useLayoutPersistence } from './hooks/useLayoutPersistence';
-import { getGeoPlayers, getHeatmap, getHistoricalSessions, getGhostData, getScenes, getGhostStats, getHotzones, downloadHotzone, deleteHotzone } from './api';
+import { getGeoPlayers, getHeatmap, getHistoricalSessions, getGhostData, getScenes, getGhostStats, getHotzones, downloadHotzone, deleteHotzone, getHotzoneDownloadLink, buildRunbinUrl } from './api';
 import {
   KNOWN_PLATFORMS,
   getPlatform,
@@ -203,7 +203,7 @@ const countryFlag = (countryCode?: string | null): string => {
   return Array.from(code).map((char) => String.fromCodePoint(char.charCodeAt(0) + 127397)).join('');
 };
 
-const HistoryOverview = ({ sessions, hotzones, onDownloadHotzone, onDeleteHotzone }: { sessions: any[]; hotzones?: any[]; onDownloadHotzone?: (hotzoneId: string, label?: string) => void; onDeleteHotzone?: (hotzoneId: string, label?: string) => void }) => {
+const HistoryOverview = ({ sessions, hotzones, onDownloadHotzone, onDeleteHotzone, onPlayRunbin }: { sessions: any[]; hotzones?: any[]; onDownloadHotzone?: (hotzoneId: string, label?: string) => void; onDeleteHotzone?: (hotzoneId: string, label?: string) => void; onPlayRunbin?: (hotzoneId: string, label?: string) => void; }) => {
   const cleanSessions = useMemo(() => sessions.filter(isDashboardSession), [sessions]);
   // Map player_id -> display name from the (already tag-enriched) session rows,
   // so the hotzone list can show a friendly label instead of the raw id.
@@ -371,6 +371,17 @@ const HistoryOverview = ({ sessions, hotzones, onDownloadHotzone, onDeleteHotzon
                       aria-label="Descargar captura hotzone"
                     >
                       <Download size={14} />
+                    </button>
+                  )}
+                  {onPlayRunbin && (
+                    <button
+                      type="button"
+                      onClick={() => onPlayRunbin(hz.id, name)}
+                      className="border-2 border-[#44cc44] bg-[#44cc44]/10 p-1.5 text-[#44cc44] hover:bg-[#44cc44] hover:text-black"
+                      title="Reproducir en Netlify"
+                      aria-label="Reproducir hotzone en Netlify"
+                    >
+                      ▶
                     </button>
                   )}
                   {onDeleteHotzone && (
@@ -1299,6 +1310,17 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
       notify.success('Hotzone descargada');
     } catch {
       notify.error('No se pudo descargar la hotzone');
+    }
+  }, []);
+
+  // Fetch a signed URL and open the HTML5 build with ?runbin=  to replay the hotzone in the browser.
+  const handlePlayRunbin = useCallback(async (hotzoneId: string, label?: string) => {
+    try {
+      const { url } = await getHotzoneDownloadLink(hotzoneId);
+      window.open(buildRunbinUrl(url), '_blank');
+      notify.success('Abriendo captura en Netlify...');
+    } catch {
+      notify.error('No se pudo generar enlace de reproducción');
     }
   }, []);
 
@@ -2362,7 +2384,7 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
             <div className={`min-h-0 overflow-y-auto ${historyMobileView === 'list' ? 'hidden xl:block' : ''}`}>
               {!selectedSession ? (
                 <div className="min-h-full p-1">
-                  <HistoryOverview sessions={historySessionsWithGeo} hotzones={hotzones} onDownloadHotzone={handleDownloadHotzone} onDeleteHotzone={handleDeleteHotzone} />
+                  <HistoryOverview sessions={historySessionsWithGeo} hotzones={hotzones} onDownloadHotzone={handleDownloadHotzone} onDeleteHotzone={handleDeleteHotzone} onPlayRunbin={handlePlayRunbin} />
                 </div>
               ) : playbackLoading ? (
                 <div className="flex h-full items-center justify-center">

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -176,6 +176,20 @@ export async function downloadHotzone(hotzoneId: string, suggestedName?: string)
   URL.revokeObjectURL(url);
 }
 
+// Get a signed download-link for reproducing a hotzone in the HTML5 build.
+export async function getHotzoneDownloadLink(hotzoneId: string) {
+  const response = await apiFetch(`/hotzones/${encodeURIComponent(hotzoneId)}/dl-link`);
+  if (!response.ok) throw new Error(`dl-link failed (${response.status})`);
+  return response.json(); // { url: "..." }
+}
+
+const NETLIFY_BUILD_URL = "https://odisea.netlify.app";
+
+// Generate a URL that can be passed to the HTML5 build to auto-play a hotzone.
+export function buildRunbinUrl(signedUrl: string): string {
+  return `${NETLIFY_BUILD_URL}/?runbin=${encodeURIComponent(signedUrl)}`;
+}
+
 // Delete a hotzone ghost (DB row + backing blob) on the central server.
 export async function deleteHotzone(hotzoneId: string) {
   const response = await apiFetch(`/hotzones/${encodeURIComponent(hotzoneId)}`, {

--- a/docs/features/FD-214-runbin-html5.md
+++ b/docs/features/FD-214-runbin-html5.md
@@ -1,0 +1,148 @@
+# FD-214: Runbin HTML5 — Reproducir hotzones .bin desde URL en build web
+
+**Status:** Open
+**Priority:** High
+**Effort:** Medium
+**Created:** 2026-06-15
+**Completed:** -
+
+## Problem
+
+Actualmente las hotzones .bin (capturas de bajo FPS con HZN2 format) solo pueden reproducirse localmente con `runbin.sh`. En el dashboard web ya se pueden listar y descargar, pero para depurar una hotzone el desarrollador debe descargarla manualmente y arrastrarla a Godot. No hay forma de hacer clic en una hotzone del dashboard y verla reproducirse directamente en el build HTML5 de Odisea.
+
+## Solution
+
+Permitir que `odisea_shell.html` acepte `?runbin=URL` como query param: si está presente, el shell descarga el .bin y lo pasa al Engine para que arranque directo en HotzonePlayer con ese bin. Y que el dashboard tenga un botón "▶ Reproducir en Netlify" por cada hotzone que genere el link.
+
+### Considered Options
+
+- **Option A — HotzonePlayer con HTTPRequest interno (GDScript)**:
+   El shell pasa la URL como argumento cmdline al Engine. HotzonePlayer.gd detecta el argumento y hace HTTPRequest al bin remoto.
+   Pros: mínimo cambio en shell. Cons: CORS — el bin viene del bridge (odisea.educa.juegos:5003) y el build corre en netlify.app, requiere cabeceras Access-Control-Allow-Origin. Además Godot HTML5 puede tener issues con HTTPRequest + binarios grandes.
+
+- **Option B — Shell fetch + engine.loadFiles()**:
+   El shell detecta `?runbin=`, fetch() al bin como ArrayBuffer, y lo pasa al engine vía `engine.loadFiles()` como VirtualFileSystem en `user://hotzones/`.
+   Pros: sin CORS (el fetch lo hace el shell, cualquier origen ok). Godot lo ve como archivo local. El engine ya está funcionando con el VirtualFS de Emscripten.
+   Contras: `engine.loadFiles()` carga archivos en el VFS del engine ANTES de que arranque — si ya arrancó no funciona. Hay que llamarlo antes de `engine.startGame()`.
+
+- **Option C — Shell fetch + IDBFS + parámetro cmdline**:
+   Similar a B pero guardando en IndexedDB via Emscripten's IDBFS mount ANTES de iniciar el engine. HotzonePlayer arranca y lee desde ahí.
+   Contras: IDBFS requiere que el engine ya haya iniciado y montado el filesystem — catch-22.
+
+- **Selected: Option B** (con variante — el shell descarga el bin, lo inyecta al VFS como recurso, y arranca el engine apuntando a HotzonePlayer.tscn). Es la ruta más limpia: el shell es quien fetcha (sin CORS, sin auth issues si usamos tokens temporales en URL), y el engine solo ve un archivo local.
+
+### Decisión de Auth
+
+El endpoint `/hotzones/:id/download` del bridge requiere Bearer token (el del dashboard). El shell en Netlify no tiene ese token. Soluciones posibles:
+
+1. **Token temporal en URL**: El dashboard, al clickear "Reproducir", llama a un nuevo endpoint del bridge `GET /hotzones/:id/gentoken` que devuelve una URL firmada con token efímero (ej: 5 min de validez). El link generado es:
+   `https://odisea.netlify.app/?runbin=https://odisea.educa.juegos:5003/hotzones/:id/download?token=XXXX`
+
+2. **Proxy público con expiración**: El bridge copia el bin a un bucket público (ej: R2/S3 con URL firmada) y devuelve esa URL. Más overhead operativo.
+
+**Seleccionado:** Solución 1 — un endpoint nuevo en el bridge `GET /hotzones/:id/dl-link` que devuelve `{"url": "..."}` con un token JWT de un solo uso o temporal.
+
+## Cambios necesarios
+
+### Bridge Central (odisea_central.py)
+
+Nuevo endpoint:
+```
+GET /hotzones/<id>/dl-link
+Auth: Bearer token (admin/dashboard)
+Response: { "url": "https://odisea.educa.juegos:5003/hotzones/<id>/download?token=<jwt>" }
+```
+
+El token JWT:
+- TTL: 5 minutos
+- Claims: `{ "hotzone_id": "<id>", "action": "download", "exp": <unix> }`
+- Firmado con secret compartido (la misma variable `ODISEA_BRIDGE_TOKEN` o una nueva `RUNBIN_TOKEN_SECRET`)
+
+El endpoint `/hotzones/<id>/download` debe aceptar `?token=JWT` como alternativa al Bearer header. Verificar JWT, si es válido servir el bin. El JWT incluye el hotzone_id para evitar reuso cross-hotzone.
+
+### odisea_shell.html
+
+1. Al inicio, parsear `URLSearchParams` para detectar `runbin`.
+2. Si `runbin` presente:
+   - Mostrar step en loading: "Descargando captura de rendimiento..."
+   - fetch(runbinURL) → await response.arrayBuffer()
+   - Mostrar "Cargando captura en el motor..."
+   - Configurar engine con `$GODOT_CONFIG` pero modificando `fileSizes.preload` y `args` para que arranque en HotzonePlayer.tscn
+   - Usar mecanismo de Godot HTML5 para pasar el bin como archivo preload (ver Godot 3 export docs para `engine.loadFiles()` o alternativa)
+3. Si no hay `runbin`, comportamiento normal (Odisea game actual).
+
+**⚠️ NOTA:** Godot 3 HTML5 permite `engine.loadFiles(files: string[])` que copia archivos al VirtualFS antes de `startGame`. Pero esto es para archivos que el juego lee desde `res://`. Para `user://` necesitamos IDBFS. Mejor alternativa: arrancar el engine normalmente y que el GDScript de entrada (un script autoload o el propio HotzonePlayer) reciba el bin por query param.
+
+**FLUJO REVISADO (más realista para Godot 3 HTML5):**
+
+a. Shell detecta `?runbin=URL`
+b. Shell fetch() del bin como ArrayBuffer
+c. Shell inicia engine normalmente (con la escena normal del juego o con HotzonePlayer.tscn como escena inicial)
+d. El shell expone el bin en `window.OdiseaShell.pendingRunbin = arrayBuffer` antes de llamar `engine.startGame()`
+e. Al llegar Godot a `_ready()` del autoload o del HotzonePlayer, hace `JavaScript.eval("window.OdiseaShell.pendingRunbin")` para obtener el bin, lo escribe a `user://` con File API de Godot, y procede a cargarlo.
+
+Este flujo evita pelear con `loadFiles()` y es más sencillo.
+
+### Dashboard (React)
+
+En el componente de lista de hotzones (HistoryOverview en App.tsx), junto al botón de descargar, agregar botón "▶ Reproducir":
+
+```tsx
+<button
+  type="button"
+  onClick={async () => {
+    try {
+      const res = await apiFetch(`/hotzones/${hz.id}/dl-link`);
+      const { url } = await res.json();
+      window.open(`https://odisea.netlify.app/?runbin=${encodeURIComponent(url)}`, '_blank');
+    } catch (e) {
+      notify.error('No se pudo generar link de reproducción');
+    }
+  }}
+  title="Reproducir en Netlify"
+  aria-label="Reproducir hotzone en Netlify"
+>
+  ▶
+</button>
+```
+
+Necesita import:
+- `apiFetch` desde `./api` (ya importada)
+- Comprobar que la URL de Netlify venga de una variable de entorno o config
+
+**Opción más simple (sin endpoint extra):** El dashboard puede generar el link sin llamar al bridge, asumiendo que el shell en Netlify fetcha directamente del bridge. Pero entonces el shell no tiene token. Esto fuerza a usar la solución del token temporal sí o sí, porque es el dashboard quien tiene el token y puede generar el link firmado.
+
+### HotzonePlayer.gd (modificaciones mínimas)
+
+Agregar detección de modo "web runbin":
+- En `_ready()`, si `OS.has_feature("web")`, buscar el bin en `JavaScript.eval()` 
+   o en `OS.get_cmdline_args()`.
+- Si encuentra el bin blob, escribirlo a `user://` con `File` API de Godot, 
+   luego `_load_binary(ruta)` como siempre.
+
+Alternativamente: si pasamos `--replay-file` como argumento cmdline al engine, 
+`OS.get_cmdline_args()` ya funciona en HTML5 (Godot lo parsea del query string 
+`?arg1=val1&arg2=val2`). Podríamos pasar `?replay-file=user://hotzones/remote.bin` 
+y que el shell ya haya inyectado el archivo en IDBFS.
+
+### Scripts / CI
+
+- `scripts/ci_export.sh`: sin cambios — el build HTML5 ya genera `odisea_shell.html` con los tokens `$GODOT_CONFIG`, `$GODOT_URL`, `$GODOT_PROJECT_NAME`, `$GODOT_HEAD_INCLUDE`, `$ODISEA_TOTAL_BYTES`. Las modificaciones al shell no afectan el reemplazo de tokens.
+- El deploy a Netlify es el mismo.
+
+## Files to Modify
+
+1. `core_v2/telemetry/html/odisea_shell.html` — agregar detección `?runbin=`, fetch, inyección al engine
+2. `core_v2/tools/HotzonePlayer.gd` — agregar soporte para recibir bin vía `JavaScript.eval()` en web
+3. `odisea_central.py` — nuevo endpoint `GET /hotzones/<id>/dl-link` + modificar `GET /hotzones/<id>/download` para aceptar token query param
+4. `dashboard/src/components/HistoryOverview.tsx` / `dashboard/src/App.tsx` — botón "▶ Reproducir en Netlify"
+5. `dashboard/src/api.ts` — nueva función `getHotzoneDownloadLink(id)`
+
+## Verification
+
+1. Arrancar dashboard, clickear "▶ Reproducir" en una hotzone → se abre nueva tab con Netlify + `?runbin=URL`
+2. La URL del token expira a los 5 min → sin token válido, bridge devuelve 401
+3. `odisea_shell.html` con `?runbin=URL` inválida → error visible en loading screen, no crashea
+4. `odisea_shell.html` sin `?runbin` → comportamiento normal (juego actual)
+5. HotzonePlayer en web reproduce frames correctamente (verificar 3 hotzones distintas)
+6. En local, `runbin.sh --file hotzone.bin` sigue funcionando (regresión)

--- a/odisea_central.py
+++ b/odisea_central.py
@@ -1357,9 +1357,28 @@ class OdiseaCentral:
             return web.json_response({"error": str(e)}, status=500)
 
     async def handle_hotzone_download(self, request):
-        guard = self._auth_guard(request)
-        if guard is not None:
-            return guard
+        # Accept either Bearer token (dashboard) or ?runbin_token= (signed URL for HTML5)
+        token = request.query.get("runbin_token")
+        if token:
+            try:
+                parts = token.split(":")
+                if len(parts) != 2:
+                    return web.json_response({"error": "invalid_token"}, status=401)
+                expiry, sig = parts
+                expiry_int = int(expiry)
+                if time.time() > expiry_int:
+                    return web.json_response({"error": "token_expired"}, status=401)
+                hz_id = request.match_info.get('id')
+                payload = f"{hz_id}:{expiry_int}"
+                expected = hmac.new(BRIDGE_TOKEN.encode(), payload.encode(), hashlib.sha256).hexdigest()[:16]
+                if sig != expected:
+                    return web.json_response({"error": "invalid_signature"}, status=401)
+            except (ValueError, IndexError):
+                return web.json_response({"error": "invalid_token"}, status=401)
+        else:
+            guard = self._auth_guard(request)
+            if guard is not None:
+                return guard
 
         hz_id = request.match_info.get('id')
         try:
@@ -1373,9 +1392,11 @@ class OdiseaCentral:
 
             fpath = await self._run_query(fetch)
             if fpath and os.path.exists(fpath):
-                return web.FileResponse(fpath, headers={
+                resp = web.FileResponse(fpath, headers={
                     "Content-Disposition": f'attachment; filename="hotzone_{hz_id}.bin"'
                 })
+                resp.headers["Access-Control-Allow-Origin"] = "*"
+                return resp
             return web.Response(status=404, text="Hotzone not found")
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
@@ -1408,6 +1429,37 @@ class OdiseaCentral:
                     logger.warning(f"Hotzone {hz_id} row deleted but blob removal failed: {exc}")
             logger.info(f"Hotzone deleted: {hz_id}")
             return web.json_response({"ok": True, "id": hz_id})
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def handle_hotzone_dl_link(self, request):
+        """Generate a signed temporary URL for hotzone download (runnable in HTML5 build)."""
+        guard = self._auth_guard(request)
+        if guard is not None:
+            return guard
+
+        hz_id = request.match_info.get('id')
+        try:
+            def fetch():
+                conn = self._get_db()
+                cursor = conn.cursor()
+                cursor.execute("SELECT file_path FROM hotzones WHERE id = ?", (hz_id,))
+                row = cursor.fetchone()
+                conn.close()
+                return row[0] if row else None
+
+            fpath = await self._run_query(fetch)
+            if not fpath or not os.path.exists(fpath):
+                return web.json_response({"error": "not_found"}, status=404)
+
+            expiry = int(time.time()) + 300  # 5 min TTL
+            payload = f"{hz_id}:{expiry}"
+            sig = hmac.new(BRIDGE_TOKEN.encode(), payload.encode(), hashlib.sha256).hexdigest()[:16]
+            token = f"{expiry}:{sig}"
+            base_url = f"{request.scheme}://{request.host}"
+            download_url = f"{base_url}/hotzones/{hz_id}/download?runbin_token={token}"
+            logger.info(f"Hotzone dl-link generated: {hz_id} (expires in 5m)")
+            return web.json_response({"url": download_url})
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
 
@@ -2979,6 +3031,7 @@ class OdiseaCentral:
             web.post('/hotzone', self.handle_hotzone_upload),
             web.get('/hotzones', self.handle_hotzones_list),
             web.get('/hotzones/{id}/download', self.handle_hotzone_download),
+            web.get('/hotzones/{id}/dl-link', self.handle_hotzone_dl_link),
             web.delete('/hotzones/{id}', self.handle_hotzone_delete),
             web.post('/command', self.handle_command),
             web.get('/health', self.handle_health),


### PR DESCRIPTION
## Resumen

Permite reproducir capturas .bin de hotzones directamente desde el build HTML5 de Odisea (Netlify), sin necesidad de descargar + arrastrar a Godot.

## Cambios

### odisea_shell.html
- Detecta query param `?runbin=URL` al cargar
- Descarga el .bin via fetch(), lo expone en `window.OdiseaShell.pendingRunbin`
- Arranca el Engine apuntando a HotzonePlayer.tscn

### HotzonePlayer.gd
- En web: recibe el bin desde `JavaScript.eval()`, lo escribe a `user://hotzones/remote.bin`, lo carga con `_load_binary()`
- Desktop: mismo comportamiento que antes (args cmdline)

### Bridge (odisea_central.py)
- Nuevo endpoint `GET /hotzones/{id}/dl-link`: genera URL firmada HMAC (5min TTL) — solo accesible con Bearer token (dashboard)
- `GET /hotzones/{id}/download`: ahora acepta `?runbin_token=` como alternativa al Bearer + añade `Access-Control-Allow-Origin: *` para CORS

### Dashboard (React)
- Botón ▶ en cada hotzone que:
  1. Pide URL firmada al bridge
  2. Abre `odisea.netlify.app/?runbin=<url_firmada>`
- Nueva función `getHotzoneDownloadLink(id)` y `buildRunbinUrl(url)` en api.ts

## Verificación
1. Click ▶ en una hotzone del dashboard → abre Netlify con ?runbin=
2. Netlify descarga el bin, arranca HotzonePlayer, reproduce frames
3. Token expira a los 5 min → sin token válido, bridge devuelve 401
4. Shell sin ?runbin → comportamiento normal
5. Desktop: `runbin.sh` sigue funcionando igual

Closes FD-214