### PR TITLE
Fix Determinism Tests Timeout — Paralelizar + Aumentar Límite

### DIFF
--- a/.github/workflows/determinism_tests.yml
+++ b/.github/workflows/determinism_tests.yml
@@ -23,10 +23,53 @@ env:
 
 jobs:
   determinism-tests:
-    name: Run Determinism Tests
+    name: Run Determinism Tests (${{ matrix.group }})
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [A, B]
+        include:
+          - group: A
+            tests: >-
+              test_locomocion_adelante
+              test_locomocion_atras
+              test_locomocion_strafe
+              test_locomocion_walk
+              test_salto_vertical
+              test_salto_desplazamiento
+              test_camara_rotacion
+              test_dome_crio_airlock_multi_cycle
+              test_dome_crio_airlock_regret_pre60
+              test_dome_crio_airlock_return
+              test_dome_crio_airlock_transition
+              test_push_clipping
+              test_push_integration
+              test_tube_airlock
+              test_killzone_signal
+              test_reverse_tank
+              test_sidescroll_acrobatic
+              test_sgc_orbit
+          - group: B
+            tests: >-
+              test_cargol_basic
+              test_cargol_starter
+              test_cinematic_input_latch
+              test_destroyer_debug
+              test_ghost_trigger_loop
+              test_oys_trigger
+              test_pro
+              test_scaffold_wfc
+              test_zero_g_roll_ots_camera
+              test_anna_scene_visual
+              test_anna_v2_telemetry
+              debug_perf
+              perf_ab_test
+              perf_test
+              reproduction_blend
+              run_test_zg
     permissions:
       contents: read
 
@@ -99,9 +142,10 @@ jobs:
         env:
           GODOT_BIN: /usr/local/bin/godot
           ODISEA_SKIP_PREFLIGHT: "1"
+          TEST_LIST: ${{ matrix.tests }}
         run: |
           mkdir -p reports
-          echo "Running determinism tests with 60s timeout per test"
+          echo "Running determinism tests group ${{ matrix.group }} with 120s timeout per test"
           echo "Issue #64: Some tests may hang or fail in CI"
           passed=0
           failed=0
@@ -109,11 +153,10 @@ jobs:
           last_test=""
           failed_cases=""
           timeout_cases=""
-          for oys_file in core_v2/tests/*.oys; do
-            oys_name=$(basename "$oys_file" .oys)
+          for oys_name in $TEST_LIST; do
             last_test="$oys_name"
             echo "Running: $oys_name"
-            if timeout 60 ./runtest.sh --oys "$oys_name" > "reports/${oys_name}.log" 2>&1; then
+            if timeout 120 ./runtest.sh --oys "$oys_name" > "reports/${oys_name}.log" 2>&1; then
               if grep -q "✅ Test OYS" "reports/${oys_name}.log" 2>/dev/null; then
                 echo "✅ $oys_name"
                 passed=$((passed + 1))


### PR DESCRIPTION
This PR addresses the timeout issues in the `Determinism Tests` workflow (FD-216). 

The following changes were implemented:
1. **Parallelization**: The 34 `.oys` tests are now split into two groups (Group A with 18 tests and Group B with 16 tests) using a GitHub Actions matrix strategy. This reduces the total wall-clock time significantly.
2. **Increased Job Timeout**: The overall job `timeout-minutes` has been increased from 25 to 45 minutes to provide enough headroom for both groups to complete, even with setup overhead.
3. **Increased Test Timeout**: Individual test execution now has a 120-second timeout (up from 60s). This prevents slow-running tests (like airlock cycles) from failing the job due to a single-test timeout, while still capturing genuine hangs.
4. **Improved Reporting**: The workflow summary reporting remains intact and works correctly with the parallelized jobs.

These changes ensure that the determinism tests actually run to completion and provide feedback on regressions, which was previously blocked by the 25-minute workflow limit.

---
*PR created automatically by Jules for task [2841540944032796342](https://jules.google.com/task/2841540944032796342) started by @icarito*