### PR TITLE
Implement Version Check and Notification System

### DIFF
--- a/core_v2/Constants.gd
+++ b/core_v2/Constants.gd
@@ -1,0 +1,3 @@
+extends Node
+
+const GAME_VERSION = "v0.3.2"

--- a/core_v2/systems/VersionChecker.gd
+++ b/core_v2/systems/VersionChecker.gd
@@ -1,0 +1,83 @@
+extends Node
+
+signal new_version_available(version_data)
+
+const CHECK_INTERVAL_SECONDS = 1800 # 30 minutes
+const CENTRAL_URL = "https://odisea.educa.juegos/game/version"
+
+var has_update := false
+var latest_version_data := {}
+var _check_timer: Timer
+
+func _ready():
+	_check_timer = Timer.new()
+	_check_timer.wait_time = CHECK_INTERVAL_SECONDS
+	_check_timer.one_shot = false
+	_check_timer.connect("timeout", self, "check_for_updates")
+	add_child(_check_timer)
+
+	# Small delay to let the game initialize and potentially have internet access settled
+	yield(get_tree().create_timer(5.0), "timeout")
+	check_for_updates()
+	_check_timer.start()
+
+func check_for_updates():
+	var http = HTTPRequest.new()
+	add_child(http)
+	http.connect("request_completed", self, "_on_request_completed", [http])
+
+	var err = http.request(CENTRAL_URL)
+	if err != OK:
+		printerr("[VersionChecker] Failed to start HTTP request: ", err)
+		http.queue_free()
+
+func _on_request_completed(result, response_code, _headers, body, http_node):
+	http_node.queue_free()
+
+	if result != HTTPRequest.RESULT_SUCCESS or response_code != 200:
+		print("[VersionChecker] Request failed or server returned non-200. Silently ignoring.")
+		return
+
+	var json_res = JSON.parse(body.get_string_from_utf8())
+	if json_res.error != OK:
+		print("[VersionChecker] Failed to parse JSON response. Silently ignoring.")
+		return
+
+	var data = json_res.result
+	if typeof(data) != TYPE_DICTIONARY or not data.has("version"):
+		print("[VersionChecker] Invalid data format in response. Silently ignoring.")
+		return
+
+	var remote_version = data["version"]
+	var local_version = Constants.GAME_VERSION
+
+	if _is_newer_version(local_version, remote_version):
+		has_update = true
+		latest_version_data = data
+		emit_signal("new_version_available", data)
+		print("[VersionChecker] New version available: ", remote_version, " (Local: ", local_version, ")")
+	else:
+		print("[VersionChecker] Game is up to date (", local_version, ")")
+
+func _is_newer_version(p_local: String, p_remote: String) -> bool:
+	# Simple semantic version comparison or just different string comparison if one is v0.x.x
+	# For simplicity as requested, if remote != local and remote is not v0.0.0
+	if p_remote == "v0.0.0" or p_remote == "":
+		return false
+
+	if p_local == p_remote:
+		return false
+
+	# Basic SemVer-ish comparison
+	var local_parts = p_local.replace("v", "").split(".")
+	var remote_parts = p_remote.replace("v", "").split(".")
+
+	for i in range(min(local_parts.size(), remote_parts.size())):
+		var lp = int(local_parts[i])
+		var rp = int(remote_parts[i])
+		if rp > lp:
+			return true
+		if lp > rp:
+			return false
+
+	return remote_parts.size() > local_parts.size()

--- a/core_v2/telemetry/ANNAV2.gd
+++ b/core_v2/telemetry/ANNAV2.gd
@@ -1,7 +1,6 @@
 extends Node
 
 const PLAYER_ID_FILE := "user://odisea_player_id.txt"
-const GAME_VERSION := "0.1.0"
 const CAPTURE_DEFAULT_MAX := 36000 # ~10 min at 60 fps; ring buffer caps memory use
 
 var _command_queue_script = preload("res://core_v2/telemetry/ANNAV2_CommandQueue.gd")
@@ -90,7 +89,7 @@ func _ready():
 		if proto == "https:":
 			_net_thread.set_scheme("wss")
 
-	_net_thread.start(_command_queue, _player_id, _session_id, _build_info.get("game_version", GAME_VERSION))
+	_net_thread.start(_command_queue, _player_id, _session_id, _build_info.get("game_version", Constants.GAME_VERSION))
 	_init_capture_from_env()
 	_perf_monitor = get_node_or_null("/root/PerformanceMonitor")
 	_perf_profiling_enabled = _perf_monitor and "_profiling_enabled" in _perf_monitor and _perf_monitor._profiling_enabled
@@ -493,7 +492,7 @@ func dump_telemetry_json(path := "") -> String:
 	var payload = {
 		"player_id": _player_id,
 		"session_id": _session_id,
-		"game_version": _build_info.get("game_version", GAME_VERSION),
+		"game_version": _build_info.get("game_version", Constants.GAME_VERSION),
 		"git_commit": _build_info.get("git_commit", ""),
 		"build_id": _build_info.get("build_id", ""),
 		"build_channel": _build_info.get("build_channel", ""),
@@ -622,7 +621,7 @@ func _load_build_info() -> Dictionary:
 	if game_version == "":
 		game_version = _get_build_meta_value("version")
 	if game_version == "":
-		game_version = GAME_VERSION
+		game_version = Constants.GAME_VERSION
 
 	var git_commit = OS.get_environment("ODISEA_GIT_COMMIT")
 	if git_commit == "":

--- a/core_v2/ui/VersionNotification.gd
+++ b/core_v2/ui/VersionNotification.gd
@@ -1,0 +1,52 @@
+extends CanvasLayer
+
+onready var panel = $Control/MarginContainer/PanelContainer
+onready var label = $Control/MarginContainer/PanelContainer/MarginContainer/VBoxContainer/Label
+onready var downloads_button = $Control/MarginContainer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/DownloadsButton
+onready var close_button = $Control/MarginContainer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer/CloseButton
+
+var _downloads_url := ""
+var _is_dismissed := false
+
+func _ready():
+	panel.hide()
+
+	if not VersionChecker.is_connected("new_version_available", self, "_on_new_version_available"):
+		VersionChecker.connect("new_version_available", self, "_on_new_version_available")
+
+	close_button.connect("pressed", self, "_on_close_pressed")
+	downloads_button.connect("pressed", self, "_on_downloads_pressed")
+
+	# Check if VersionChecker already has an update found (it might have run before we were instanced)
+	if VersionChecker.has_update and not _is_dismissed:
+		_show_notification(VersionChecker.latest_version_data)
+
+func _on_new_version_available(data: Dictionary):
+	if not _is_dismissed:
+		_show_notification(data)
+
+func _show_notification(data: Dictionary):
+	var new_ver = data.get("version", "v?.?.?")
+	_downloads_url = data.get("downloads_page", "")
+
+	if OS.get_name() == "HTML5":
+		label.text = "v%s disponible — recarga para obtenerla" % new_ver
+		downloads_button.hide()
+	else:
+		label.text = "v%s disponible" % new_ver
+		downloads_button.show()
+
+	panel.show()
+
+	# Optional: Animation or Sound
+	if has_node("AnimationPlayer"):
+		$AnimationPlayer.play("show")
+
+func _on_close_pressed():
+	panel.hide()
+	_is_dismissed = true
+
+func _on_downloads_pressed():
+	if _downloads_url != "":
+		OS.shell_open(_downloads_url)
+	_on_close_pressed()

--- a/core_v2/ui/VersionNotification.tscn
+++ b/core_v2/ui/VersionNotification.tscn
@@ -1,0 +1,68 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://core_v2/ui/VersionNotification.gd" type="Script" id=1]
+[ext_resource path="res://assets/themes/retro_scifi.tres" type="Theme" id=2]
+
+[node name="VersionNotification" type="CanvasLayer"]
+layer = 100
+script = ExtResource( 1 )
+
+[node name="Control" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+theme = ExtResource( 2 )
+
+[node name="MarginContainer" type="MarginContainer" parent="Control"]
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -300.0
+margin_bottom = 100.0
+mouse_filter = 2
+custom_constants/margin_right = 20
+custom_constants/margin_top = 20
+
+[node name="PanelContainer" type="PanelContainer" parent="Control/MarginContainer"]
+margin_top = 20.0
+margin_right = 280.0
+margin_bottom = 100.0
+
+[node name="MarginContainer" type="MarginContainer" parent="Control/MarginContainer/PanelContainer"]
+margin_left = 7.0
+margin_top = 7.0
+margin_right = 273.0
+margin_bottom = 73.0
+custom_constants/margin_right = 10
+custom_constants/margin_top = 10
+custom_constants/margin_left = 10
+custom_constants/margin_bottom = 10
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Control/MarginContainer/PanelContainer/MarginContainer"]
+margin_left = 10.0
+margin_top = 10.0
+margin_right = 256.0
+margin_bottom = 56.0
+
+[node name="Label" type="Label" parent="Control/MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
+margin_right = 246.0
+margin_bottom = 14.0
+text = "v0.0.0 disponible"
+align = 1
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
+margin_top = 18.0
+margin_right = 246.0
+margin_bottom = 38.0
+alignment = 1
+
+[node name="DownloadsButton" type="Button" parent="Control/MarginContainer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+margin_left = 34.0
+margin_right = 138.0
+margin_bottom = 20.0
+text = "Ver descargas"
+
+[node name="CloseButton" type="Button" parent="Control/MarginContainer/PanelContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+margin_left = 142.0
+margin_right = 211.0
+margin_bottom = 20.0
+text = "Ignorar"

--- a/odisea_central.py
+++ b/odisea_central.py
@@ -37,6 +37,10 @@ def inflate_ws_frame(data: bytes) -> Optional[bytes]:
 # --- Configuration ---
 CENTRAL_HTTP_PORT = int(os.environ.get("CENTRAL_HTTP_PORT", 5003))
 
+GITHUB_RELEASES_URL = "https://api.github.com/repos/icarito/Odisea/releases/latest"
+DOWNLOADS_PAGE_URL = "https://icarito.github.io/odisea-neon-dreams/#downloads"
+WEB_URL = "https://odisea-game.netlify.app"
+
 # PWA Push Notifications (FD-167)
 VAPID_PUBLIC_KEY = os.environ.get("ODISEA_VAPID_PUBLIC_KEY")
 VAPID_PRIVATE_KEY = os.environ.get("ODISEA_VAPID_PRIVATE_KEY")
@@ -607,6 +611,45 @@ class OdiseaCentral:
     # --- Request Handlers ---
     async def handle_health(self, request):
         return web.json_response(self.metrics.get_metrics(self))
+
+    async def handle_game_version(self, request):
+        """Returns the latest game version from GitHub Releases with 5-min caching."""
+        now = time.time()
+        if hasattr(self, "_game_version_cache"):
+            cache_ts, cache_data = self._game_version_cache
+            if now - cache_ts < 300:  # 5 minutes TTL
+                return web.json_response(cache_data, headers={"Access-Control-Allow-Origin": "*"})
+
+        try:
+            import urllib.request
+            req = urllib.request.Request(
+                GITHUB_RELEASES_URL,
+                headers={"Accept": "application/vnd.github.v3+json", "User-Agent": "Odisea-Central-Bridge"}
+            )
+            # Fetch from GitHub API (sync call in executor)
+            def fetch():
+                with urllib.request.urlopen(req, timeout=5) as response:
+                    return json.loads(response.read().decode())
+
+            data = await asyncio.get_running_loop().run_in_executor(None, fetch)
+            version = data.get("tag_name", "v0.0.0")
+            release_url = data.get("html_url", "")
+
+            version_info = {
+                "version": version,
+                "latest_release_url": release_url,
+                "web_url": WEB_URL,
+                "downloads_page": DOWNLOADS_PAGE_URL
+            }
+            self._game_version_cache = (now, version_info)
+            return web.json_response(version_info, headers={"Access-Control-Allow-Origin": "*"})
+
+        except Exception as e:
+            logger.warning(f"Failed to fetch game version from GitHub: {e}")
+            # Fallback to last cached if available, even if expired
+            if hasattr(self, "_game_version_cache"):
+                return web.json_response(self._game_version_cache[1], headers={"Access-Control-Allow-Origin": "*"})
+            return web.json_response({"error": "failed_to_fetch_version"}, status=502, headers={"Access-Control-Allow-Origin": "*"})
 
     async def handle_web_telemetry(self, request):
         """Unauthenticated loader metrics from the HTML shell (fire and forget).
@@ -3031,6 +3074,7 @@ class OdiseaCentral:
             web.get('/api/player-tags', self.handle_player_tags_list),
             web.post('/api/player-tags', self.handle_player_tag_upsert),
             web.delete('/api/player-tags/{player_id}', self.handle_player_tag_delete),
+            web.get('/game/version', self.handle_game_version),
             web.post('/telemetry', self.handle_web_telemetry),
             web.get('/telemetry/web', self.handle_web_telemetry_list),
             web.options('/telemetry', self.handle_web_telemetry_options),

--- a/project.godot
+++ b/project.godot
@@ -2270,6 +2270,8 @@ output_latency.web=100
 
 [autoload]
 
+Constants="*res://core_v2/Constants.gd"
+VersionChecker="*res://core_v2/systems/VersionChecker.gd"
 DomeRegistry="*res://core_v2/data/DomeRegistry.gd"
 AudioManager="*res://core_v2/autoloads/AudioManager.gd"
 SessionManager="*res://core_v2/autoloads/SessionManager.gd"
@@ -2295,6 +2297,7 @@ SceneLighting="*res://core_v2/autoloads/SceneLighting.gd"
 AirlockManager="*res://core_v2/autoloads/AirlockManager.gd"
 ANNAV2="*res://core_v2/telemetry/ANNAV2.gd"
 HotzoneRecorder="*res://core_v2/telemetry/HotzoneRecorder.gd"
+VersionNotification="*res://core_v2/ui/VersionNotification.tscn"
 
 [debug]
 


### PR DESCRIPTION
This PR introduces a mechanism to notify players when a new version of the game is available. It includes a new endpoint in the bridge server that fetches the latest release from GitHub, and game-side Autoloads to check this endpoint and display a platform-specific notification toast (WebGL players are prompted to reload, while Native players get a link to the downloads page).

---
*PR created automatically by Jules for task [15235515281242270227](https://jules.google.com/task/15235515281242270227) started by @icarito*