### PR TITLE
ci(export): gate multiplatform release on green pytest run

### DIFF
--- a/.github/workflows/export_all.yml
+++ b/.github/workflows/export_all.yml
@@ -31,16 +31,52 @@ permissions:
 jobs:
   prep:
     runs-on: ubuntu-latest
+    # Only run when the triggering test run succeeded. Manual dispatches have
+    # no workflow_run payload, so the conclusion check passes through.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       version: ${{ steps.meta.outputs.version }}
       sha: ${{ steps.meta.outputs.sha }}
       channel: ${{ steps.meta.outputs.channel }}
+      # Branch and full SHA, normalized across workflow_run and workflow_dispatch
+      # so downstream jobs never have to read github.ref / github.event_name,
+      # which mean different things under workflow_run.
+      ref_name: ${{ steps.meta.outputs.ref_name }}
+      head_sha: ${{ steps.meta.outputs.head_sha }}
+      is_dispatch: ${{ steps.meta.outputs.is_dispatch }}
+      publish_prerelease: ${{ steps.meta.outputs.publish_prerelease }}
     steps:
-      - uses: actions/checkout@v4
-      - id: meta
+      - id: ctx
         run: |
-          SHA=$(git rev-parse --short HEAD)
+          # Resolve the branch and commit being built. Under workflow_run these
+          # come from the triggering run; under workflow_dispatch from the ref
+          # the workflow was launched against.
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            REF_NAME="${{ github.event.workflow_run.head_branch }}"
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          else
+            REF_NAME="${{ github.ref_name }}"
+            HEAD_SHA="${{ github.sha }}"
+          fi
+          echo "ref_name=$REF_NAME" >> $GITHUB_OUTPUT
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ctx.outputs.head_sha }}
+      - id: meta
+        env:
+          REF_NAME: ${{ steps.ctx.outputs.ref_name }}
+          HEAD_SHA: ${{ steps.ctx.outputs.head_sha }}
+        run: |
+          SHA=$(git rev-parse --short "$HEAD_SHA")
           echo "sha=$SHA" >> $GITHUB_OUTPUT
+          echo "ref_name=$REF_NAME" >> $GITHUB_OUTPUT
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+
+          IS_DISPATCH=false
+          [ "${{ github.event_name }}" = "workflow_dispatch" ] && IS_DISPATCH=true
+          echo "is_dispatch=$IS_DISPATCH" >> $GITHUB_OUTPUT
+          echo "publish_prerelease=${{ github.event.inputs.publish_prerelease }}" >> $GITHUB_OUTPUT
 
           # Base version from project.godot. Some dev builds do not define it,
           BASE_VERSION=$(grep -E "^application/config/version=" project.godot | head -n 1 | cut -d"\"" -f2 || true)
@@ -50,9 +86,9 @@ jobs:
 
           # Determine channel
           CHANNEL="dev"
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "$REF_NAME" = "main" ]; then
             CHANNEL="nightly"
-          elif [ "${{ github.ref }}" = "refs/heads/release" ]; then
+          elif [ "$REF_NAME" = "release" ]; then
             CHANNEL="release"
           fi
 
@@ -115,6 +151,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prep.outputs.head_sha }}
 
       # `secrets` and `matrix` can't be used in a job-level `if`, so gate iOS at
       # the step level instead: detect missing certs here and skip the iOS-only
@@ -166,7 +204,7 @@ jobs:
         run: |
           python3 scripts/inject_build_meta.py \
             --token "${{ secrets.ODISEA_CENTRAL_INGEST_TOKEN }}" \
-            --commit "${{ github.sha }}" \
+            --commit "${{ needs.prep.outputs.head_sha }}" \
             --build-id "${{ github.run_id }}" \
             --channel "${{ needs.prep.outputs.channel }}" \
             --version "${{ needs.prep.outputs.version }}" \
@@ -465,7 +503,7 @@ jobs:
   deploy-web:
     needs: [prep, export]
     runs-on: ubuntu-latest
-    if: ${{ always() && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ always() && needs.prep.result == 'success' && (needs.prep.outputs.ref_name == 'main' || needs.prep.outputs.is_dispatch == 'true') }}
     permissions:
       contents: read
       deployments: write
@@ -499,7 +537,7 @@ jobs:
           publish-dir: netlify-build/
           production-branch: main
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deploy from ${{ github.sha }}"
+          deploy-message: "Deploy from ${{ needs.prep.outputs.sha }}"
           netlify-config-path: ./
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -512,7 +550,7 @@ jobs:
   release:
     needs: [prep, export]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_prerelease == 'false')
+    if: needs.prep.outputs.ref_name == 'release' || (needs.prep.outputs.is_dispatch == 'true' && needs.prep.outputs.publish_prerelease == 'false')
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -535,10 +573,12 @@ jobs:
   nightly:
     needs: [prep, export]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_prerelease == 'true')
+    if: needs.prep.outputs.ref_name == 'main' || (needs.prep.outputs.is_dispatch == 'true' && needs.prep.outputs.publish_prerelease == 'true')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prep.outputs.head_sha }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -583,7 +623,7 @@ jobs:
             --title "Nightly Tip" \
             --notes-file body.md \
             --prerelease \
-            --target "${{ github.sha }}" \
+            --target "${{ needs.prep.outputs.head_sha }}" \
             "${RELEASE_FILES[@]}"
 
       - name: Discord Notification


### PR DESCRIPTION
Release Multiplataforma se disparaba con push a main/release sin esperar a los tests, así que un commit roto (p.ej. el syntax error 'not in' en HotzoneRecorder.gd recién mergeado) igual arrancaba el export y podía publicar un release de un build roto.

Cambia el trigger a workflow_run encadenado tras 'Odyssey Pytest Runner'; prep aborta salvo conclusion == success. workflow_dispatch sigue permitiendo builds manuales que saltan el gate intencionalmente.

Normaliza branch/SHA en outputs de prep (ref_name/head_sha/is_dispatch/ publish_prerelease) para que los jobs no lean github.ref/github.event_name, que cambian de semántica bajo workflow_run, y hace checkout del head_sha correcto en export/nightly.