### PR TITLE
FD-227 Jules A: navegación 5 tabs + cockpit + filtros globales

### DIFF
--- a/core_v2/systems/gas/GasArea3D.gd.bak.1780965074
+++ b/core_v2/systems/gas/GasArea3D.gd.bak.1780965074
@@ -1,0 +1,422 @@
+extends Area
+class_name GasArea3D
+
+const GasParticleManagerScript = preload("res://core_v2/systems/gas/GasParticleManager.gd")
+
+signal gas_ignited(pos, rad)
+
+enum GasType { TOXIC, FLAMMABLE, STEAM }
+
+export(int, "Toxic", "Flammable", "Steam") var gas_type := GasType.TOXIC setget set_gas_type
+export(float) var viscosity := 0.8
+export(float) var buoyancy := -1.2
+export(float) var decay_rate := 1.0
+export(bool) var is_flammable := false
+export(float) var player_push_force := 15.0
+export(float) var damage_per_second := 20.0
+export(int) var grid_resolution := 32 setget set_grid_resolution
+export(float) var dense_damage_threshold := 1.0
+export(float) var min_combustion_density := 0.6
+export(float) var combustion_radius := 1.6
+export(float) var combustion_damage_radius := 2.0
+export(int) var initial_particle_count := 128
+export(float) var initial_fill_radius := 0.85
+export(float) var initial_vertical_fill := 0.45
+export(float) var initial_particle_scale := 3.0
+export(float) var initial_particle_lifetime := 60.0
+export(bool) var gas_collide_with_world := true
+export(int, LAYERS_3D_PHYSICS) var gas_world_collision_mask := 1
+export(bool) var initial_respect_world_collision := true
+
+var manager = null
+
+var _grid: Array = []
+var _cell_particles: Array = []
+var _burning_cells: Dictionary = {}
+var _bodies_inside: Dictionary = {}
+var _collision_shape: CollisionShape = null
+
+func _ready():
+	_resolve_collision_shape()
+	_ensure_manager()
+	_ensure_grid()
+	_connect_signals()
+	_apply_manager_tuning()
+	call_deferred("_populate_initial_gas")
+
+func set_gas_type(value: int) -> void:
+	gas_type = value
+	if gas_type == GasType.FLAMMABLE:
+		is_flammable = true
+
+func set_grid_resolution(value: int) -> void:
+	grid_resolution = int(clamp(value, 4, 128))
+	if is_inside_tree():
+		_ensure_grid()
+
+func _resolve_collision_shape() -> void:
+	_collision_shape = get_node_or_null("CollisionShape")
+	if _collision_shape == null:
+		for child in get_children():
+			if child is CollisionShape:
+				_collision_shape = child
+				break
+
+func _ensure_manager() -> void:
+	for child in get_children():
+		if child.get_script() == GasParticleManagerScript:
+			manager = child
+			break
+
+	if manager == null:
+		manager = GasParticleManagerScript.new()
+		manager.name = "GasParticleManager"
+		add_child(manager)
+
+func _connect_signals() -> void:
+	if not is_connected("body_entered", self, "_on_body_entered"):
+		connect("body_entered", self, "_on_body_entered")
+	if not is_connected("body_exited", self, "_on_body_exited"):
+		connect("body_exited", self, "_on_body_exited")
+
+func _ensure_grid() -> void:
+	grid_resolution = int(clamp(grid_resolution, 4, 128))
+	var cell_count := grid_resolution * grid_resolution
+	_grid.clear()
+	_cell_particles.clear()
+	for _i in range(cell_count):
+		_grid.append({
+			"density": 0.0,
+			"temperature": 0.0,
+			"en_combustion": false
+		})
+		_cell_particles.append([])
+
+func _physics_process(delta: float) -> void:
+	if Engine.editor_hint:
+		return
+	if manager == null:
+		return
+
+	_apply_manager_tuning()
+	_update_body_velocities(delta)
+	_rebuild_density_grid()
+	_apply_body_push(delta)
+	_apply_player_damage(delta)
+	if is_flammable:
+		_update_combustion(delta)
+
+func _apply_manager_tuning() -> void:
+	if manager == null:
+		return
+	manager.viscosity = viscosity
+	manager.buoyancy = buoyancy
+	manager.decay_rate = decay_rate
+	manager.collide_with_world = gas_collide_with_world
+	manager.world_collision_mask = gas_world_collision_mask
+	# Pass volume radius so manager can normalize particle distances
+	var extents := _get_shape_extents()
+	manager.volume_radius = max(extents.x, max(extents.y, extents.z))
+
+func _clear_grid() -> void:
+	for i in range(_grid.size()):
+		var cell: Dictionary = _grid[i]
+		cell["density"] = 0.0
+		cell["temperature"] = 0.0
+		cell["en_combustion"] = _burning_cells.has(i)
+		_grid[i] = cell
+		_cell_particles[i].clear()
+
+func _rebuild_density_grid() -> void:
+	_clear_grid()
+
+	for i in range(manager.particles.size()):
+		var particle: Dictionary = manager.particles[i]
+		if not bool(particle["active"]):
+			continue
+
+		var world_pos: Vector3 = manager.global_transform.xform(Vector3(particle["position"]))
+		var cell_index := _world_position_to_cell_index(world_pos)
+		if cell_index < 0:
+			continue
+
+		var cell: Dictionary = _grid[cell_index]
+		cell["density"] = float(cell["density"]) + 1.0
+		if bool(particle["combustion"]):
+			cell["temperature"] = max(float(cell["temperature"]), 1.0)
+		_grid[cell_index] = cell
+		_cell_particles[cell_index].append(i)
+
+func _world_position_to_cell_index(world_pos: Vector3) -> int:
+	var shape_pos := _world_to_shape_local(world_pos)
+	var extents := _get_shape_extents()
+	if extents.x <= 0.001 or extents.z <= 0.001:
+		return -1
+
+	var nx := (shape_pos.x / extents.x + 1.0) * 0.5
+	var nz := ((-shape_pos.z) / extents.z + 1.0) * 0.5
+	if nx < 0.0 or nx > 1.0 or nz < 0.0 or nz > 1.0:
+		return -1
+
+	var gx := int(clamp(floor(nx * float(grid_resolution)), 0.0, float(grid_resolution - 1)))
+	var gz := int(clamp(floor(nz * float(grid_resolution)), 0.0, float(grid_resolution - 1)))
+	return _cell_index(gx, gz)
+
+func _world_to_shape_local(world_pos: Vector3) -> Vector3:
+	if _collision_shape:
+		return _collision_shape.to_local(world_pos)
+	return to_local(world_pos)
+
+func _get_shape_extents() -> Vector3:
+	if _collision_shape and _collision_shape.shape is BoxShape:
+		return (_collision_shape.shape as BoxShape).extents
+	if _collision_shape and _collision_shape.shape is CapsuleShape:
+		var capsule := _collision_shape.shape as CapsuleShape
+		return Vector3(capsule.radius, capsule.height * 0.5 + capsule.radius, capsule.radius)
+	if _collision_shape and _collision_shape.shape is SphereShape:
+		var sphere := _collision_shape.shape as SphereShape
+		return Vector3(sphere.radius, sphere.radius, sphere.radius)
+	return Vector3(4.0, 2.0, 4.0)
+
+func _populate_initial_gas() -> void:
+	if manager == null or initial_particle_count <= 0:
+		return
+	if manager.get_active_particle_indices().size() > 0:
+		return
+
+	if initial_particle_count > manager.pool_size:
+		manager.pool_size = initial_particle_count
+		manager._ensure_multimesh_instance()
+		manager._setup_pool()
+
+	var extents := _get_shape_extents()
+	var count := int(min(initial_particle_count, manager.pool_size))
+	var fill_x := clamp(initial_fill_radius, 0.05, 5.0)
+	var fill_y := clamp(initial_vertical_fill, 0.05, 5.0)
+	var fill_z := fill_x
+
+	for i in range(count):
+		var u_x := fmod(float(i) * 0.7548776662466927, 1.0)
+		var u_y := fmod(float(i) * 0.5698402909980532, 1.0)
+		var u_z := fmod(float(i) * 0.4323369283944646, 1.0)
+
+		# Add deterministic noise (jitter) to break the grid regularity
+		var jitter_x := (float((i * 1103515245 + 12345) & 0x7fffffff) / float(0x7fffffff) - 0.5) * 0.3
+		var jitter_y := (float((i * 214013 + 2531011) & 0x7fffffff) / float(0x7fffffff) - 0.5) * 0.3
+		var jitter_z := (float((i * 1664525 + 1013904223) & 0x7fffffff) / float(0x7fffffff) - 0.5) * 0.3
+
+		var shape_pos := Vector3(
+			(clamp(u_x + jitter_x, 0.0, 1.0) - 0.5) * 2.0 * extents.x * fill_x,
+			(clamp(u_y + jitter_y, 0.0, 1.0) - 0.5) * 2.0 * extents.y * fill_y,
+			(clamp(u_z + jitter_z, 0.0, 1.0) - 0.5) * 2.0 * extents.z * fill_z
+		)
+		var world_pos: Vector3 = _shape_local_to_world(shape_pos)
+		if initial_respect_world_collision and _is_world_point_blocked(world_pos):
+			continue
+		var manager_pos: Vector3 = manager.to_local(world_pos)
+		manager.emit_particle(manager_pos, Vector3.ZERO, initial_particle_lifetime, initial_particle_scale)
+
+func _shape_local_to_world(local_pos: Vector3) -> Vector3:
+	if _collision_shape:
+		return _collision_shape.global_transform.xform(local_pos)
+	return global_transform.xform(local_pos)
+
+func _is_world_point_blocked(world_pos: Vector3) -> bool:
+	var space_state = get_world().direct_space_state
+	var hits: Array = space_state.intersect_point(world_pos, 1, [], gas_world_collision_mask, true, false)
+	return hits.size() > 0
+
+func _cell_index(x: int, z: int) -> int:
+	return z * grid_resolution + x
+
+func _cell_coords(index: int) -> Vector2:
+	return Vector2(index % grid_resolution, int(index / grid_resolution))
+
+func _on_body_entered(body: Node) -> void:
+	if body == null:
+		return
+	var id: int = body.get_instance_id()
+	var pos: Vector3 = body.global_transform.origin if body is Spatial else Vector3.ZERO
+	_bodies_inside[id] = {
+		"body": body,
+		"last_position": pos,
+		"velocity": Vector3.ZERO
+	}
+
+func _on_body_exited(body: Node) -> void:
+	if body == null:
+		return
+	_bodies_inside.erase(body.get_instance_id())
+
+func _update_body_velocities(delta: float) -> void:
+	var remove_ids := []
+	for id in _bodies_inside.keys():
+		var info: Dictionary = _bodies_inside[id]
+		var body = info.get("body", null)
+		if not is_instance_valid(body):
+			remove_ids.append(id)
+			continue
+		if not body is Spatial:
+			continue
+
+		var current_pos: Vector3 = body.global_transform.origin
+		var velocity := Vector3.ZERO
+		if body is RigidBody:
+			velocity = body.linear_velocity
+		elif delta > 0.0:
+			velocity = (current_pos - Vector3(info["last_position"])) / delta
+
+		info["velocity"] = velocity
+		info["last_position"] = current_pos
+		_bodies_inside[id] = info
+
+	for id in remove_ids:
+		_bodies_inside.erase(id)
+
+func _apply_body_push(delta: float) -> void:
+	var radius := max(player_push_force, 0.001)
+	for id in _bodies_inside.keys():
+		var info: Dictionary = _bodies_inside[id]
+		var body = info.get("body", null)
+		if not is_instance_valid(body) or not body is Spatial:
+			continue
+
+		var velocity: Vector3 = info.get("velocity", Vector3.ZERO)
+		if velocity.length_squared() < 0.0001:
+			continue
+
+		manager.apply_velocity_impulse(body.global_transform.origin, radius, velocity, 1.0, delta)
+
+func _apply_player_damage(delta: float) -> void:
+	if damage_per_second <= 0.0:
+		return
+
+	for id in _bodies_inside.keys():
+		var info: Dictionary = _bodies_inside[id]
+		var body = info.get("body", null)
+		if not is_instance_valid(body) or not body is Spatial:
+			continue
+		if not _is_player_body(body):
+			continue
+
+		var cell_index := _world_position_to_cell_index(body.global_transform.origin)
+		if cell_index < 0:
+			continue
+
+		var density := float(_grid[cell_index]["density"])
+		if density > dense_damage_threshold:
+			_apply_damage(body, damage_per_second * delta)
+
+func _is_player_body(body: Node) -> bool:
+	if body.is_in_group("player"):
+		return true
+	return body.name.to_lower().find("player") >= 0
+
+func _apply_damage(body: Node, amount: float) -> void:
+	if body.has_method("take_damage"):
+		body.call("take_damage", amount)
+	elif body.has_method("apply_damage"):
+		body.call("apply_damage", amount)
+	elif body.has_method("damage"):
+		body.call("damage", amount)
+
+func ignite_at_global_position(world_pos: Vector3, radius: float = -1.0) -> void:
+	if not is_flammable:
+		return
+	var cell_index := _world_position_to_cell_index(world_pos)
+	if cell_index < 0:
+		return
+
+	_mark_cell_ignited(cell_index)
+	_emit_ignition(world_pos, combustion_radius if radius <= 0.0 else radius)
+
+func ignite_at_local_cell(x: int, z: int) -> void:
+	if not is_flammable:
+		return
+	if x < 0 or z < 0 or x >= grid_resolution or z >= grid_resolution:
+		return
+
+	var index := _cell_index(x, z)
+	_mark_cell_ignited(index)
+	_emit_ignition(_cell_to_world_position(x, z), combustion_radius)
+
+func apply_thermal_damage(world_pos: Vector3, amount: float, radius: float = -1.0) -> void:
+	if amount <= 0.0:
+		return
+	ignite_at_global_position(world_pos, radius)
+
+func _mark_cell_ignited(index: int) -> void:
+	_burning_cells[index] = 0.0
+	if index >= 0 and index < _grid.size():
+		var cell: Dictionary = _grid[index]
+		cell["en_combustion"] = true
+		cell["temperature"] = 1.0
+		_grid[index] = cell
+		for particle_index in _cell_particles[index]:
+			manager.set_particle_combustion(int(particle_index), true)
+
+func _update_combustion(delta: float) -> void:
+	var new_cells := []
+	var dead_cells := []
+
+	for index in _burning_cells.keys():
+		var burn_time := float(_burning_cells[index]) + delta
+		_burning_cells[index] = burn_time
+		if burn_time > 4.0:
+			dead_cells.append(index)
+			continue
+
+		if index >= 0 and index < _cell_particles.size():
+			for particle_index in _cell_particles[index]:
+				manager.set_particle_combustion(int(particle_index), true)
+
+		var coords := _cell_coords(int(index))
+		for offset in [Vector2(1, 0), Vector2(-1, 0), Vector2(0, 1), Vector2(0, -1)]:
+			var nx := int(coords.x + offset.x)
+			var nz := int(coords.y + offset.y)
+			if nx < 0 or nz < 0 or nx >= grid_resolution or nz >= grid_resolution:
+				continue
+			var neighbor_index := _cell_index(nx, nz)
+			if _burning_cells.has(neighbor_index):
+				continue
+			if float(_grid[neighbor_index]["density"]) >= min_combustion_density:
+				new_cells.append(neighbor_index)
+
+	for index in dead_cells:
+		_burning_cells.erase(index)
+
+	for index in new_cells:
+		if not _burning_cells.has(index):
+			_mark_cell_ignited(index)
+			var coords := _cell_coords(index)
+			_emit_ignition(_cell_to_world_position(int(coords.x), int(coords.y)), combustion_radius)
+
+func _cell_to_world_position(x: int, z: int) -> Vector3:
+	var extents := _get_shape_extents()
+	var nx := (float(x) + 0.5) / float(grid_resolution)
+	var nz := (float(z) + 0.5) / float(grid_resolution)
+	var shape_pos := Vector3(
+		lerp(-extents.x, extents.x, nx),
+		0.0,
+		-lerp(-extents.z, extents.z, nz)
+	)
+	if _collision_shape:
+		return _collision_shape.global_transform.xform(shape_pos)
+	return global_transform.xform(shape_pos)
+
+func _emit_ignition(world_pos: Vector3, radius: float) -> void:
+	for id in _bodies_inside.keys():
+		var info: Dictionary = _bodies_inside[id]
+		var body = info.get("body", null)
+		if not is_instance_valid(body) or not body is Spatial:
+			continue
+		var distance: float = body.global_transform.origin.distance_to(world_pos)
+		if distance <= combustion_damage_radius:
+			_apply_damage(body, damage_per_second * 0.5)
+
+	emit_signal("gas_ignited", world_pos, radius)
+
+func get_grid_cell(x: int, z: int) -> Dictionary:
+	if x < 0 or z < 0 or x >= grid_resolution or z >= grid_resolution:
+		return {}
+	return _grid[_cell_index(x, z)].duplicate()

--- a/core_v2/systems/gas/GasParticleManager.gd.bak.1780965074
+++ b/core_v2/systems/gas/GasParticleManager.gd.bak.1780965074
@@ -1,0 +1,399 @@
+extends Spatial
+class_name GasParticleManager
+
+export(int) var pool_size := 512
+export(float) var default_max_lifetime := 6.0
+export(float) var default_base_scale := 2.2
+export(float) var viscosity := 0.8
+export(float) var buoyancy := -1.2
+export(float) var decay_rate := 1.0
+export(Color) var default_color := Color(0.62, 0.78, 0.74, 0.82)
+export(Color) var ignition_color := Color(1.0, 0.42, 0.08, 0.82)
+export(float, -1.0, 1.0) var distance_luminance_shift := -0.4
+export(float, -1.0, 1.0) var distance_r_shift := 0.0
+export(float, -1.0, 1.0) var distance_g_shift := 0.0
+export(float, -1.0, 1.0) var distance_b_shift := 0.0
+
+# Set by GasArea3D from shape extents — used to normalize particle distance
+var volume_radius := 4.0
+export(bool) var collide_with_world := true
+export(int, LAYERS_3D_PHYSICS) var world_collision_mask := 1
+export(float) var collision_margin := 0.08
+export(float) var collision_damping := 0.28
+export(float) var collision_slide := 0.68
+export(float) var flipbook_frames_per_second := 16.0
+export(float) var anim_speed_base := 1.0
+export(float) var anim_speed_velocity_factor := 0.2
+export(String, FILE, "*.shader") var shader_path := "res://core_v2/systems/gas/shaders/gas_flipbook.shader"
+export(String, FILE, "*.png,*.tga,*.webp,*.jpg") var default_atlas_path := "res://assets/flipbook_particles/assets/clouds/textures/cloud_01.tga"
+
+var particles: Array = []
+var multimesh_instance: MultiMeshInstance = null
+var multimesh: MultiMesh = null
+
+var _next_spawn_index := 0
+var _hidden_transform := Transform.IDENTITY
+var _gas_material: ShaderMaterial = null
+
+func _init():
+	add_to_group("replay_sync")
+
+func _ready():
+	_hidden_transform.basis = _hidden_transform.basis.scaled(Vector3.ZERO)
+	_ensure_multimesh_instance()
+	_setup_pool()
+	_sync_all_instances()
+
+func _ensure_multimesh_instance() -> void:
+	multimesh_instance = get_node_or_null("GasMultiMeshInstance")
+	if multimesh_instance == null:
+		multimesh_instance = MultiMeshInstance.new()
+		multimesh_instance.name = "GasMultiMeshInstance"
+		add_child(multimesh_instance)
+
+	multimesh_instance.cast_shadow = 0 # GeometryInstance.SHADOW_CASTING_SETTING_OFF
+	multimesh_instance.extra_cull_margin = 32.0
+
+	multimesh = multimesh_instance.multimesh
+	if multimesh == null:
+		multimesh = MultiMesh.new()
+		multimesh_instance.multimesh = multimesh
+
+	if multimesh.instance_count > 0:
+		multimesh.instance_count = 0
+	multimesh.transform_format = MultiMesh.TRANSFORM_3D
+	multimesh.color_format = MultiMesh.COLOR_FLOAT
+	multimesh.custom_data_format = MultiMesh.CUSTOM_DATA_FLOAT
+	multimesh.instance_count = max(1, pool_size)
+	multimesh.visible_instance_count = multimesh.instance_count
+
+	if multimesh.mesh == null:
+		var quad := QuadMesh.new()
+		quad.size = Vector2(1.0, 1.0)
+		multimesh.mesh = quad
+
+	_ensure_material()
+
+func _ensure_material() -> void:
+	if multimesh_instance.material_override is ShaderMaterial:
+		_gas_material = multimesh_instance.material_override
+	else:
+		_gas_material = ShaderMaterial.new()
+		var shader = load(shader_path)
+		if shader:
+			_gas_material.shader = shader
+		multimesh_instance.material_override = _gas_material
+
+	if _gas_material and _gas_material.shader:
+		var atlas = load(default_atlas_path)
+		if atlas:
+			_gas_material.set_shader_param("smoke_atlas", atlas)
+		_gas_material.set_shader_param("frames_per_second", flipbook_frames_per_second)
+
+func _setup_pool() -> void:
+	pool_size = max(1, pool_size)
+	particles.clear()
+	for i in range(pool_size):
+		particles.append({
+			"active": false,
+			"position": Vector3.ZERO,
+			"velocity": Vector3.ZERO,
+			"lifetime": 0.0,
+			"max_lifetime": default_max_lifetime,
+			"base_scale": default_base_scale,
+			"color": default_color,
+			"combustion": false,
+			"anim_time": 0.0,
+			"anim_offset": _get_deterministic_anim_offset(i)
+		})
+
+func _physics_process(delta: float) -> void:
+	if Engine.editor_hint:
+		return
+	step(delta)
+
+func step(delta: float) -> void:
+	if multimesh == null:
+		return
+
+	var gravity_y := _get_local_gravity_y()
+	var friction := clamp(1.0 - viscosity * delta, 0.0, 1.0)
+
+	for i in range(particles.size()):
+		var p: Dictionary = particles[i]
+		if not bool(p["active"]):
+			continue
+
+		var velocity: Vector3 = p["velocity"]
+		velocity.y += buoyancy * gravity_y * delta
+		velocity *= friction
+
+		var position: Vector3 = p["position"]
+		var move_result: Dictionary = _move_particle_with_collision(position, velocity, delta)
+		position = move_result["position"]
+		velocity = move_result["velocity"]
+
+		var lifetime := float(p["lifetime"]) + delta * max(decay_rate, 0.0)
+		var max_lifetime := max(float(p["max_lifetime"]), 0.001)
+
+		var speed := velocity.length()
+		var p_anim_mod: float = float(p.get("anim_speed_mod", 1.0))
+		var anim_delta: float = delta * (anim_speed_base * p_anim_mod + speed * anim_speed_velocity_factor)
+
+		p["velocity"] = velocity
+		p["position"] = position
+		p["lifetime"] = lifetime
+		p["anim_time"] = float(p.get("anim_time", 0.0)) + anim_delta
+
+		if lifetime >= max_lifetime:
+			p["active"] = false
+			p["combustion"] = false
+			p["color"] = default_color
+			particles[i] = p
+			_hide_instance(i)
+		else:
+			particles[i] = p
+			_sync_instance(i)
+
+func _get_local_gravity_y() -> float:
+	var gravity_world = get_node_or_null("/root/GravityWorld")
+	if gravity_world and gravity_world.has_method("get_physical_gravity"):
+		var gravity_vec: Vector3 = gravity_world.get_physical_gravity(global_transform.origin)
+		if gravity_vec.length_squared() > 0.000001:
+			return gravity_vec.y
+
+	var default_gravity := 9.8
+	if ProjectSettings.has_setting("physics/3d/default_gravity"):
+		default_gravity = float(ProjectSettings.get_setting("physics/3d/default_gravity"))
+	return -abs(default_gravity)
+
+func _move_particle_with_collision(local_position: Vector3, local_velocity: Vector3, delta: float) -> Dictionary:
+	var target_position: Vector3 = local_position + local_velocity * delta
+	if not collide_with_world:
+		return {
+			"position": target_position,
+			"velocity": local_velocity
+		}
+	if local_position.distance_squared_to(target_position) <= 0.000001:
+		return {
+			"position": target_position,
+			"velocity": local_velocity
+		}
+
+	var space_state = get_world().direct_space_state
+	var from_world: Vector3 = global_transform.xform(local_position)
+	var to_world: Vector3 = global_transform.xform(target_position)
+	var result: Dictionary = space_state.intersect_ray(from_world, to_world, [], world_collision_mask, true, false)
+	if result.empty():
+		return {
+			"position": target_position,
+			"velocity": local_velocity
+		}
+
+	var normal: Vector3 = result.get("normal", Vector3.UP).normalized()
+	var hit_position: Vector3 = result.get("position", from_world)
+	var world_velocity: Vector3 = global_transform.basis.xform(local_velocity)
+	var normal_speed: float = world_velocity.dot(normal)
+	if normal_speed < 0.0:
+		var normal_component: Vector3 = normal * normal_speed
+		var tangent_component: Vector3 = world_velocity - normal_component
+		world_velocity = (tangent_component * collision_slide) - (normal_component * collision_damping)
+
+	var adjusted_world_position: Vector3 = hit_position + normal * max(collision_margin, 0.0)
+	return {
+		"position": to_local(adjusted_world_position),
+		"velocity": global_transform.basis.xform_inv(world_velocity)
+	}
+
+func emit_particle(local_position: Vector3, local_velocity: Vector3 = Vector3.ZERO, max_lifetime: float = -1.0, base_scale: float = -1.0, color: Color = Color(0, 0, 0, -1)) -> int:
+	var index := _next_spawn_index
+	_next_spawn_index = (_next_spawn_index + 1) % particles.size()
+
+	var p: Dictionary = particles[index]
+	p["active"] = true
+	p["position"] = local_position
+	p["velocity"] = local_velocity
+	p["lifetime"] = 0.0
+	p["max_lifetime"] = default_max_lifetime if max_lifetime <= 0.0 else max_lifetime
+	
+	var base_s = default_base_scale if base_scale <= 0.0 else base_scale
+	p["base_scale"] = base_s * (0.5 + _get_deterministic_anim_offset(index + 777) * 1.0)
+	
+	var c = default_color if color.a < 0.0 else color
+	var dist := local_position.length()
+	p["color"] = _get_varied_color(c, index, dist)
+	
+	p["combustion"] = false
+	p["anim_time"] = 0.0
+	p["anim_offset"] = _get_deterministic_anim_offset(index)
+	p["anim_speed_mod"] = 0.5 + _get_deterministic_anim_offset(index + 1234) * 1.5
+	particles[index] = p
+	_sync_instance(index)
+	return index
+
+func _get_deterministic_anim_offset(index: int) -> float:
+	var hashed := int((index * 1103515245 + 12345) & 0x7fffffff)
+	return float(hashed % 1000) / 1000.0
+
+func emit_burst(local_origin: Vector3, count: int, radius: float = 1.0, initial_speed: float = 0.0) -> void:
+	var safe_count := max(0, count)
+	for i in range(safe_count):
+		var angle := TAU * float(i) / float(max(1, safe_count))
+		var ring := radius * (0.35 + 0.65 * float((i % 7) + 1) / 7.0)
+		var offset := Vector3(cos(angle) * ring, 0.0, -sin(angle) * ring)
+		var velocity := offset.normalized() * initial_speed if offset.length_squared() > 0.000001 else Vector3.ZERO
+		emit_particle(local_origin + offset, velocity)
+
+func apply_velocity_impulse(global_origin: Vector3, radius: float, velocity: Vector3, strength: float, delta: float) -> void:
+	var safe_radius := max(radius, 0.001)
+	var local_origin := to_local(global_origin)
+	var local_velocity := global_transform.basis.xform_inv(velocity)
+
+	for i in range(particles.size()):
+		var p: Dictionary = particles[i]
+		if not bool(p["active"]):
+			continue
+
+		var position: Vector3 = p["position"]
+		var distance := position.distance_to(local_origin)
+		if distance > safe_radius:
+			continue
+
+		var falloff := 1.0 - (distance / safe_radius)
+		p["velocity"] = Vector3(p["velocity"]) + local_velocity * strength * falloff * delta
+		particles[i] = p
+
+func set_particle_combustion(index: int, active: bool) -> void:
+	if index < 0 or index >= particles.size():
+		return
+	var p: Dictionary = particles[index]
+	if not bool(p["active"]):
+		return
+	p["combustion"] = active
+	var c = ignition_color if active else default_color
+	var dist := Vector3(p["position"]).length()
+	p["color"] = _get_varied_color(c, index, dist)
+	particles[index] = p
+	_sync_instance(index)
+
+func clear_all() -> void:
+	for i in range(particles.size()):
+		var p: Dictionary = particles[i]
+		p["active"] = false
+		p["combustion"] = false
+		p["lifetime"] = 0.0
+		p["velocity"] = Vector3.ZERO
+		p["anim_time"] = 0.0
+		particles[i] = p
+		_hide_instance(i)
+
+func get_active_particle_indices() -> Array:
+	var indices := []
+	for i in range(particles.size()):
+		if bool(particles[i]["active"]):
+			indices.append(i)
+	return indices
+
+func get_particle_world_position(index: int) -> Vector3:
+	if index < 0 or index >= particles.size():
+		return global_transform.origin
+	return global_transform.xform(Vector3(particles[index]["position"]))
+
+func _sync_all_instances() -> void:
+	for i in range(particles.size()):
+		if bool(particles[i]["active"]):
+			_sync_instance(i)
+		else:
+			_hide_instance(i)
+
+func _sync_instance(index: int) -> void:
+	if multimesh == null:
+		return
+	var p: Dictionary = particles[index]
+	var age := clamp(float(p["lifetime"]) / max(float(p["max_lifetime"]), 0.001), 0.0, 1.0)
+	var frame_time := float(p.get("anim_time", 0.0)) + float(p.get("anim_offset", 0.0))
+	var scale := max(float(p["base_scale"]), 0.001) * (0.9 + 0.6 * age)
+	var xform := Transform.IDENTITY
+	xform.origin = Vector3(p["position"])
+	xform.basis = xform.basis.scaled(Vector3(scale, scale, scale))
+	multimesh.set_instance_transform(index, xform)
+	multimesh.set_instance_color(index, Color(p["color"]))
+	multimesh.set_instance_custom_data(index, Color(age, 1.0 if bool(p["combustion"]) else 0.0, frame_time, 1.0))
+
+func _hide_instance(index: int) -> void:
+	if multimesh == null:
+		return
+	multimesh.set_instance_transform(index, _hidden_transform)
+	multimesh.set_instance_color(index, Color(0, 0, 0, 0))
+	multimesh.set_instance_custom_data(index, Color(0, 0, 0, 0))
+
+func get_snapshot() -> Dictionary:
+	var active_particles := []
+	for i in range(particles.size()):
+		var p: Dictionary = particles[i]
+		if not bool(p["active"]):
+			continue
+		active_particles.append({
+			"i": i,
+			"p": Vector3(p["position"]),
+			"v": Vector3(p["velocity"]),
+			"t": float(p["lifetime"]),
+			"m": float(p["max_lifetime"]),
+			"s": float(p["base_scale"]),
+			"c": Color(p["color"]),
+			"b": bool(p["combustion"]),
+			"a": float(p.get("anim_time", 0.0)),
+			"o": float(p.get("anim_offset", 0.0))
+		})
+
+	return {
+		"pool_size": particles.size(),
+		"next_spawn_index": _next_spawn_index,
+		"particles": active_particles
+	}
+
+func restore_snapshot(data: Dictionary) -> void:
+	if particles.empty():
+		_setup_pool()
+
+	clear_all()
+	_next_spawn_index = int(data.get("next_spawn_index", 0)) % int(max(1, particles.size()))
+
+	var active_particles: Array = data.get("particles", [])
+	for entry in active_particles:
+		if not entry is Dictionary:
+			continue
+		var index := int(entry.get("i", -1))
+		if index < 0 or index >= particles.size():
+			continue
+
+		var p: Dictionary = particles[index]
+		p["active"] = true
+		p["position"] = Vector3(entry.get("p", Vector3.ZERO))
+		p["velocity"] = Vector3(entry.get("v", Vector3.ZERO))
+		p["lifetime"] = float(entry.get("t", 0.0))
+		p["max_lifetime"] = float(entry.get("m", default_max_lifetime))
+		p["base_scale"] = float(entry.get("s", default_base_scale))
+		
+		var raw_color = Color(entry.get("c", default_color))
+		# If it's a restored snapshot, we can just use the color directly or re-apply variance.
+		# Since we save the exact color in get_snapshot(), we don't need to re-vary it here.
+		p["color"] = raw_color
+		
+		p["combustion"] = bool(entry.get("b", false))
+		p["anim_time"] = float(entry.get("a", 0.0))
+		p["anim_offset"] = float(entry.get("o", _get_deterministic_anim_offset(index)))
+		p["anim_speed_mod"] = 0.5 + _get_deterministic_anim_offset(index + 1234) * 1.5
+		particles[index] = p
+		_sync_instance(index)
+
+func _get_varied_color(base_c: Color, index: int, distance: float = 0.0) -> Color:
+	# Normalize distance (0 = center, 1 = edge of volume)
+	var norm_dist := clamp(distance / max(volume_radius, 0.001), 0.0, 1.0)
+
+	return Color(
+		clamp(base_c.r + norm_dist * (distance_luminance_shift + distance_r_shift), 0.0, 1.0),
+		clamp(base_c.g + norm_dist * (distance_luminance_shift + distance_g_shift), 0.0, 1.0),
+		clamp(base_c.b + norm_dist * (distance_luminance_shift + distance_b_shift), 0.0, 1.0),
+		base_c.a
+	)

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -2,9 +2,6 @@ import { lazy, Suspense, useState, useEffect, useMemo, useRef, useCallback, type
 import { Toaster, toast } from 'react-hot-toast';
 import { notify } from './lib/notify';
 import {
-  Bar,
-  BarChart,
-  Brush,
   CartesianGrid,
   Line,
   LineChart,
@@ -19,6 +16,13 @@ import { NotificationSettings } from './components/NotificationSettings';
 import { LiveMap } from './components/LiveMap';
 import { HistoricalTable } from './components/HistoricalTable';
 import { DashboardLayout } from './components/DashboardLayout';
+import { GlobalFilterBar } from './components/GlobalFilterBar';
+import { BreadcrumbNav } from './components/BreadcrumbNav';
+import { CockpitGrid } from './components/CockpitGrid';
+import { CockpitPanel } from './components/CockpitPanel';
+import { ActivePlayersGrid } from './components/ActivePlayersGrid';
+import { PlayerHealthCard } from './components/PlayerHealthCard';
+import { EventTimeline } from './components/EventTimeline';
 import { PlayerBottomSheet } from './components/PlayerBottomSheet';
 import { FiltersDrawer, FiltersSidebar, type SceneFilterOption, type CountryFilterOption } from './components/FiltersDrawer';
 import { LiveCombinedChart } from './components/LiveCombinedChart';
@@ -39,7 +43,7 @@ import {
   formatFpsLabel,
 } from './lib/filters';
 import { Maximize2, X, SlidersHorizontal, RotateCcw, WifiOff, Download, Trash2, Play, Tag, ChevronDown, ChevronRight } from 'lucide-react';
-import type { Tab } from './types';
+import type { Tab, NavStackItem } from './types';
 
 type GitCommit = {
   sha: string;
@@ -145,57 +149,6 @@ const fpsColor = (fps: number) => {
   return '#f85149';
 };
 
-// Standalone "Sessions per day" bar chart, shown in the Live top stripe when no
-// player is live. Reused from the HomeStats aggregation logic.
-const SessionsPerDayChart = ({ sessions }: { sessions: any[] }) => {
-  const sessionsByDay = useMemo(() => {
-    const grouped = new Map<string, number>();
-    sessions.filter(isDashboardSession).forEach((s) => {
-      const ts = Number(s.start_time) || 0;
-      if (!ts) return;
-      const day = new Date(ts * 1000).toISOString().slice(0, 10);
-      grouped.set(day, (grouped.get(day) || 0) + 1);
-    });
-    return Array.from(grouped.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([date, count]) => ({ date, count }));
-  }, [sessions]);
-
-  const tooltip = ({ active, payload }: any) => {
-    if (!active || !payload?.length) return null;
-    const d = payload[0].payload;
-    return (
-      <div className="border-2 border-black bg-bg-primary px-3 py-2 text-[0.625rem] font-mono shadow-[2px_2px_0px_0px_black]">
-        <div className="font-black text-accent">{d.date}</div>
-        <div>Sessions: {d.count}</div>
-      </div>
-    );
-  };
-
-  if (sessionsByDay.length === 0) {
-    return (
-      <div className="flex h-full items-center justify-center text-xs italic text-text-muted">
-        No session history yet
-      </div>
-    );
-  }
-
-  return (
-    <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
-      <BarChart data={sessionsByDay} margin={{ bottom: sessionsByDay.length > 10 ? 4 : 0 }}>
-        <CartesianGrid strokeDasharray="3 3" stroke="#232833" />
-        <XAxis dataKey="date" stroke="#666" fontSize={10} tickFormatter={(v) => String(v).slice(5)} />
-        <YAxis stroke="#666" fontSize={10} allowDecimals={false} />
-        <Tooltip content={tooltip} />
-        <Bar dataKey="count" fill="#7fd1ff" isAnimationActive={false} />
-        {sessionsByDay.length > 10 && (
-          <Brush dataKey="date" height={16} stroke="#7fd1ff" travellerWidth={8} fill="#0d1117"
-            tickFormatter={(v) => String(v).slice(5)} />
-        )}
-      </BarChart>
-    </ResponsiveContainer>
-  );
-};
 
 const countryFlag = (countryCode?: string | null): string => {
   const code = (countryCode || '').trim().toUpperCase();
@@ -425,13 +378,6 @@ const HistoryOverview = ({ sessions, hotzones, onDownloadHotzone, onDeleteHotzon
   );
 };
 
-// Compact label/value cell for the collapsible 3D info panel.
-const Info = ({ label, value }: { label: string; value: ReactNode }) => (
-  <div className="flex flex-col">
-    <span className="text-[0.5rem] uppercase text-text-muted">{label}</span>
-    <span className="truncate text-[0.625rem]">{value}</span>
-  </div>
-);
 
 // Historical avg-FPS-per-session line with git commit markers — useful to spot
 // which commit moved performance. Standalone so it can live in the Live top
@@ -955,7 +901,17 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
   const { layout, updateLayout } = useLayoutPersistence();
   
   const activeTab = layout.activeTab as Tab;
-  const setActiveTab = (t: Tab) => updateLayout({ activeTab: t });
+  const setActiveTab = (t: Tab) => {
+    updateLayout({ activeTab: t, navStack: [] });
+  };
+
+  const navStack = layout.navStack || [];
+  const pushNav = (item: NavStackItem) => {
+    updateLayout({ navStack: [...navStack, item] });
+  };
+  const navigateTo = (index: number) => {
+    updateLayout({ navStack: navStack.slice(0, index + 1) });
+  };
 
   // Desktop docked filters sidebar collapsed state + History min-duration
   // filter, both persisted across reloads.
@@ -993,12 +949,9 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
   const [showPlayerSheet, setShowPlayerSheet] = useState(false);
   // Live FPS/memory charts overlay over the 3D view.
   const [showLiveCharts, setShowLiveCharts] = useState(true);
-  // Selected ghost in birdseye -> floating detail card with live charts.
-  const [birdseyeDetailId, setBirdseyeDetailId] = useState<string | null>(null);
+  const [, setBirdseyeDetailId] = useState<string | null>(null);
   // Filters side drawer (platform + scene).
   const [showFilters, setShowFilters] = useState(false);
-  // Top-stripe inner tab on the Dashboard view (live combined chart vs sessions).
-  const [dashStripeTab, setDashStripeTab] = useState<'live' | 'sessions' | 'versions'>('live');
   const viewport3DPreloaded = useRef(false);
 
   // Playback loading flag (history -> playback fetch).
@@ -1198,7 +1151,7 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
                     type="button"
                     onClick={() => {
                       setSelectedPlayerId(playerId);
-                      setActiveTab('live');
+                        setActiveTab('dashboard');
                       setLiveView('3d');
                       setFollowPlayer(true);
                       toast.dismiss(t.id);
@@ -1906,7 +1859,7 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
         <div className="hidden min-w-0 items-center gap-2 border-2 border-black bg-bg-primary px-2 py-1 text-[0.625rem] font-bold md:flex">
           <button
             type="button"
-            onClick={() => { setActiveTab('live'); setLiveView('3d'); }}
+            onClick={() => { setActiveTab('dashboard'); setLiveView('3d'); }}
             title="Player activo — ver en 3D"
             className="flex min-w-0 items-center gap-2 hover:text-accent"
           >
@@ -2007,7 +1960,30 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
           )}
         </div>
       }
-      secondaryNav={activeTab === 'live' ? (
+      filterBar={
+        <GlobalFilterBar
+          selectedScene={selectedSceneFilter}
+          selectedPlatforms={selectedPlatforms}
+          selectedCountry={selectedCountry}
+          warmupSeconds={minDuration === DEFAULT_HISTORY_MIN_DURATION ? 13 : minDuration}
+          onRemoveScene={() => setSelectedSceneFilter('all')}
+          onTogglePlatform={togglePlatform}
+          onRemoveCountry={() => setSelectedCountry('all')}
+          onToggleWarmup={() => setMinDuration(minDuration > 0 ? 0 : 13)}
+          onOpenFilters={() => setShowFilters(true)}
+          allPlatforms={availablePlatforms}
+        />
+      }
+      breadcrumb={
+        navStack.length > 0 ? (
+          <BreadcrumbNav 
+            stack={navStack} 
+            onNavigate={navigateTo} 
+            onHome={() => setActiveTab('dashboard')} 
+          />
+        ) : undefined
+      }
+      secondaryNav={activeTab === 'dashboard' ? (
         <div className="flex">
           {([
             { id: 'dashboard', label: 'Dashboard', enabled: true },
@@ -2119,60 +2095,20 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
           the sidebar is a fixed-width docked column on xl+ (overlay on mobile). */}
       <div className="flex h-full min-h-0">
         <div className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
-      {activeTab === 'live' && (
-        <div className="flex flex-col h-full min-h-0">
-          {/* View area fills all remaining space; the view switcher now lives in
-              the secondary nav above the bottom bar. */}
-          <div className="flex-1 min-h-0 relative">
-            {liveView === 'dashboard' ? (
-              /* Stripe layout: charts on top, info cards below. */
-              <div className="flex h-full min-h-0 flex-col">
-                {/* Top stripe: live combined FPS/Memory chart, else Sessions/day */}
-                <CollapsibleCard
-                  title="Performance Charts"
-                  storageKey="live_charts_collapsed"
-                  defaultOpen={true}
-                  resizable={true}
-                  initialHeight={320}
-                  className="shrink-0 border-x-0 border-t-0"
-                >
-                  <div className="flex h-full flex-col bg-bg-card/40">
-                    <div className="flex shrink-0">
-                      {(activeHistory
-                        ? ([['live', 'FPS / Memoria'], ['sessions', 'Sesiones'], ['versions', 'Versiones']] as const)
-                        : ([['sessions', 'Sesiones'], ['versions', 'Versiones']] as const)
-                      ).map(([id, label]) => {
-                        const effectiveTab = activeHistory ? dashStripeTab : (dashStripeTab === 'live' ? 'sessions' : dashStripeTab);
-                        return (
-                          <button
-                            key={id}
-                            onClick={() => setDashStripeTab(id)}
-                            className={`subtab-btn ${effectiveTab === id ? 'subtab-btn-active' : ''}`}
-                          >
-                            {label}
-                          </button>
-                        );
-                      })}
-                    </div>
-                    <div className="min-h-0 flex-1 p-3">
-                      {activeHistory && dashStripeTab === 'live' ? (
-                        <LiveCombinedChart history={activeHistory} />
-                      ) : dashStripeTab === 'versions' ? (
-                        <CommitsFpsChart sessions={filteredDashboardSessions} commits={commits} />
-                      ) : (
-                        <SessionsPerDayChart sessions={filteredDashboardSessions} />
-                      )}
-                    </div>
-                  </div>
-                </CollapsibleCard>
-                {/* Bottom stripe: info cards (historical summary) */}
-                <div className="min-h-0 flex-1 overflow-y-auto">
-                  <div className="p-4 sm:p-6 pb-0">
-                  </div>
-                  <HomeStats sessions={filteredDashboardSessions} serverStats={serverStats} />
-                </div>
-              </div>
-            ) : !activeHb ? (
+      {activeTab === 'dashboard' && (
+        <CockpitGrid storageKey="cockpit_main">
+          <CockpitPanel title="Players activos" storageKey="panel_active_players" count={pids.length}>
+            <ActivePlayersGrid 
+              players={Object.values(filteredHeartbeats)} 
+              onPlayerClick={(pid) => setSelectedPlayerId(pid)}
+              onSceneClick={(scene) => setSelectedSceneFilter(scene)}
+            />
+          </CockpitPanel>
+
+          {/* Main View Area */}
+          <div className="h-full relative min-h-[400px] border-2 border-black shadow-[2px_2px_0px_0px_black] bg-bg-primary overflow-hidden flex flex-col">
+            <div className="flex-1 relative min-h-0">
+            {!activeHb ? (
               <LiveWaitTicker items={[
                 { label: 'Sesiones totales', value: String(heatmapSummary.totalSessions) },
                 { label: 'Tiempo jugado', value: formatPlayTime(heatmapSummary.totalPlaySeconds) },
@@ -2184,7 +2120,6 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
               ]} />
             ) : liveView === '3d' ? (
               <div className="flex h-full min-h-0 flex-col">
-                {/* 3D-only control bar */}
                 <div className="shrink-0 flex flex-wrap items-center gap-1 p-2 border-b-2 border-black bg-bg-card/60">
                   <RetroButton variant={followPlayer ? 'primary' : 'secondary'} onClick={() => setFollowPlayer(!followPlayer)} className="py-1 px-2 text-[0.625rem]">FOLLOW</RetroButton>
                   <RetroButton
@@ -2202,121 +2137,96 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
                 <div className="relative flex-1 min-h-0">
                   {viewport3D}
                 </div>
-                {/* Bottom panel: large live FPS+RAM chart plus an explicit metric
-                    strip. Replaces the old redundant accordion — RAM is now a
-                    first-class readout instead of hidden in the chart's right axis. */}
-                {showLiveCharts && (
-                  <div className="shrink-0 border-t-2 border-black bg-bg-card/80">
-                    <div className="grid grid-cols-2 gap-2 px-3 pt-2 text-[0.625rem] font-mono sm:grid-cols-4 lg:grid-cols-6">
-                      <Info label="FPS" value={`${formatFpsLabel(activeHb?.player?.fps).replace(' FPS', '')}${activeHb?.player?.focused === false ? ' (bg)' : ''}`} />
-                      <Info label="RAM" value={activeHb?.player?.memory_mb != null ? `${Math.round(activeHb.player.memory_mb)} MB` : '—'} />
-                      <Info label="Scene" value={activeHb?.player?.scene || '-'} />
-                      <Info label="Platform" value={getPlatform(activeHb) || '-'} />
-                      <Info label="Peers" value={otherPeerCount} />
-                      <Info label="Latency" value={`${staleAge.toFixed(1)}s`} />
-                    </div>
-                    <div className="h-40 px-2 pb-2 pt-1">
-                      <LiveCombinedChart history={activeHistory} />
-                    </div>
-                  </div>
-                )}
               </div>
             ) : (
               <>
                 {birdseyeMap}
-
                 <button
                   type="button"
                   onClick={() => setFsBirdseye(true)}
-                  className="absolute right-3 top-3 z-10 border-2 border-black bg-bg-card/90 p-2 hover:bg-accent hover:text-black"
+                  className="absolute right-3 top-3 z-10 border-2 border-black bg-bg-card/90 p-2 hover:bg-accent hover:text-black shadow-[2px_2px_0px_0px_black]"
                   title="Fullscreen map"
                   aria-label="Fullscreen map"
                 >
                   <Maximize2 size={16} />
                 </button>
-
-                {/* Live chart overlay for the active player — shown by default
-                    (top-left), like the 3D view. Hidden if charts are toggled
-                    off or there's no history yet. */}
-                {showLiveCharts && activeHistory && !birdseyeDetailId && (
-                  <div className="absolute top-3 left-3 z-10 h-28 w-60 max-w-[55vw] border-2 border-black bg-bg-card/90 p-2 shadow-[3px_3px_0px_0px_black] backdrop-blur-sm">
-                    <div className="mb-1 truncate text-[0.5625rem] font-black uppercase text-accent">{activeLabel || activeId?.slice(0, 12)}</div>
-                    <div className="h-[calc(100%-1rem)]">
-                      <LiveCombinedChart history={activeHistory} />
-                    </div>
-                  </div>
-                )}
-
-                {birdseyeDetailId && (() => {
-                  const hb = filteredHeartbeats[birdseyeDetailId];
-                  const hist = history[birdseyeDetailId];
-                  return (
-                    <div className="absolute right-3 top-3 z-20 w-64 max-w-[80vw] border-2 border-black bg-bg-card/95 p-3 shadow-[3px_3px_0px_0px_black]">
-                      <div className="mb-2 flex items-start justify-between gap-2">
-                        <div className="min-w-0">
-                          <div className="truncate text-xs font-black text-accent">{hb?.display_name || birdseyeDetailId.slice(0, 12)}</div>
-                          {hb?.display_name && <div className="truncate text-[0.5625rem] text-text-muted">{birdseyeDetailId.slice(0, 12)}</div>}
-                          <div className="truncate text-[0.625rem] text-text-muted">{hb?.player?.scene || 'scene —'}</div>
-                        </div>
-                        <button
-                          onClick={() => setBirdseyeDetailId(null)}
-                          className="shrink-0 border-2 border-black bg-bg-primary px-1.5 py-0.5 text-[0.625rem] font-black hover:bg-danger hover:text-black"
-                          aria-label="Close"
-                        >
-                          <X size={12} />
-                        </button>
-                      </div>
-                      <div className="h-28">
-                        <LiveCombinedChart history={hist} />
-                      </div>
-                      <HotzoneList
-                        sessions={hb ? [{
-                          player_id: birdseyeDetailId,
-                          session_id: hb.session_id,
-                          display_name: hb.display_name,
-                          scene: hb.player?.scene,
-                        }] : []}
-                        // HotzoneList renders every row it's given (it only uses
-                        // sessions for name lookup), so scope to this player here.
-                        hotzones={hotzones.filter((hz: any) =>
-                          hz.player_id === birdseyeDetailId || (hb?.session_id && hz.session_id === hb.session_id)
-                        )}
-                        onDownloadHotzone={handleDownloadHotzone}
-                        onPlayHotzone={handlePlayHotzone}
-                        onTagPlayer={(pid) => { setFocusPlayerId(pid); setShowTagEditor(true); }}
-                        compact
-                      />
-                      <div className="mt-2 flex gap-2">
-                        <RetroButton
-                          variant="primary"
-                          onClick={() => {
-                            setSelectedPlayerId(birdseyeDetailId);
-                            setBirdseyeDetailId(null);
-                            setLiveView('3d');
-                            setFollowPlayer(true);
-                          }}
-                          className="flex-1 py-1 text-[0.625rem]"
-                        >
-                          Ver 3D
-                        </RetroButton>
-                        <RetroButton
-                          variant="secondary"
-                          onClick={() => {
-                            const session = historySessionsWithGeo.find(s => s.session_id === hb.session_id);
-                            if (session) {
-                              handleSelectHistorySession(session);
-                              setActiveTab('history');
-                            }
-                          }}
-                          className="flex-1 py-1 text-[0.625rem]"
-                        >
-                          Historial
-                        </RetroButton>
-                      </div>
-                    </div>
-                  );
-                })()}
               </>
+            )}
+
+            {/* Player Selected State Overlay (Phase 2) */}
+            {activeHb && explicitActiveId && (
+              <div className="absolute left-3 top-3 z-20 w-80 max-w-[90vw]">
+                <PlayerHealthCard
+                  playerId={activeId}
+                  displayName={activeHb.display_name}
+                  fps={activeHb.player?.fps || 0}
+                  fpsHistory={activeHistory?.fps || []}
+                  platform={getPlatform(activeHb) || 'unknown'}
+                  scene={activeHb.player?.scene || 'unknown'}
+                  status={(activeHb.player?.fps || 0) > 45 ? 'ok' : (activeHb.player?.fps || 0) > 30 ? 'warning' : 'critical'}
+                />
+              </div>
+            )}
+            </div>
+          </div>
+
+          {/* Scoreboard (HomeStats) */}
+          <CockpitPanel title="Scoreboard" storageKey="panel_scoreboard">
+            <HomeStats sessions={filteredDashboardSessions} serverStats={serverStats} />
+          </CockpitPanel>
+
+          <CockpitPanel title="Eventos recientes" storageKey="panel_events">
+            <EventTimeline 
+              events={alerts.map(a => ({
+                id: a.id,
+                type: a.type === 'disconnect' ? 'disconnect' : 'alert',
+                playerId: a.playerId,
+                playerName: heartbeats[a.playerId]?.display_name || '',
+                timestamp: a.timestamp,
+                message: a.message,
+                scene: heartbeats[a.playerId]?.player?.scene
+              }))} 
+            />
+          </CockpitPanel>
+        </CockpitGrid>
+      )}
+
+      {activeTab === 'players' && (
+        <div className="flex h-full flex-col p-4 gap-4">
+          <div className="flex border-2 border-black">
+            <button
+              type="button"
+              onClick={() => setLiveView('dashboard')}
+              className={`subtab-btn ${liveView !== 'birdseye' ? 'subtab-btn-active' : ''}`}
+            >
+              Lista
+            </button>
+            <button
+              type="button"
+              onClick={() => setLiveView('birdseye')}
+              className={`subtab-btn ${liveView === 'birdseye' ? 'subtab-btn-active' : ''}`}
+            >
+              Globe
+            </button>
+          </div>
+          
+          <div className="flex-1 min-h-0">
+            {liveView === 'birdseye' ? (
+              <div className="h-full border-4 border-black shadow-retro overflow-hidden">
+                <Suspense fallback={<LazyPanelFallback label="Cargando globo…" />}>
+                  <GlobeView
+                    players={filteredGeoPlayers}
+                    onSelectPlayer={(playerId) => {
+                      setFocusPlayerId(playerId);
+                      setShowTagEditor(true);
+                    }}
+                  />
+                </Suspense>
+              </div>
+            ) : (
+              <div className="h-full border-4 border-black shadow-retro overflow-hidden bg-bg-card">
+                 <div className="p-4 text-xs italic text-text-muted">Lista de players (Fase 2)...</div>
+              </div>
             )}
           </div>
         </div>
@@ -2341,6 +2251,55 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
               }}
             />
           </Suspense>
+        </div>
+      )}
+
+      {activeTab === 'scenes' && (
+        <div className="flex h-full flex-col p-4 gap-4">
+          <div className="flex-1 border-4 border-black shadow-retro bg-bg-card p-4">
+            <h2 className="text-sm font-black uppercase text-accent mb-4">Índice de Escenas</h2>
+            <SceneIndex
+              sessions={filteredDashboardSessions}
+              scenes={availableSceneFilters}
+              selectedScene={selectedSceneFilter}
+              onSelectScene={(scene) => {
+                setSelectedSceneFilter(scene);
+                pushNav({ tab: 'scenes', view: scene, label: scene });
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'analysis' && (
+        <div className="flex h-full flex-col p-4 gap-4">
+          <div className="flex-1 border-4 border-black shadow-retro bg-bg-card p-4">
+            <h2 className="text-sm font-black uppercase text-accent mb-4">Análisis de Rendimiento</h2>
+            <div className="h-64 mb-6">
+              <CommitsFpsChart sessions={filteredDashboardSessions} commits={commits} />
+            </div>
+            <div className="text-xs italic text-text-muted">Más visualizaciones en Fase 5...</div>
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'replays' && (
+        <div className="flex h-full flex-col p-4 gap-4">
+          <div className="flex-1 border-4 border-black shadow-retro bg-bg-card overflow-hidden flex flex-col">
+            <div className="p-4 border-b-2 border-black bg-bg-primary">
+               <h2 className="text-sm font-black uppercase text-accent">Inbox de Hotzones</h2>
+            </div>
+            <div className="flex-1 overflow-y-auto p-4">
+               <HotzoneList
+                sessions={historySessionsWithGeo}
+                hotzones={hotzones}
+                onDownloadHotzone={handleDownloadHotzone}
+                onDeleteHotzone={handleDeleteHotzone}
+                onPlayHotzone={handlePlayHotzone}
+                onTagPlayer={(pid) => { setFocusPlayerId(pid); setShowTagEditor(true); }}
+              />
+            </div>
+          </div>
         </div>
       )}
 

--- a/dashboard/src/components/ActivePlayersGrid.tsx
+++ b/dashboard/src/components/ActivePlayersGrid.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { PlayerCard } from './PlayerCard';
+
+interface ActivePlayersGridProps {
+  players: any[];
+  onPlayerClick: (playerId: string) => void;
+  onSceneClick: (scene: string) => void;
+}
+
+export const ActivePlayersGrid: React.FC<ActivePlayersGridProps> = ({ 
+  players, 
+  onPlayerClick,
+  onSceneClick 
+}) => {
+  const playersByScene = players.reduce((acc: Record<string, any[]>, player) => {
+    const scene = player.scene || 'Unknown';
+    if (!acc[scene]) acc[scene] = [];
+    acc[scene].push(player);
+    return acc;
+  }, {});
+
+  const scenes = Object.keys(playersByScene).sort();
+
+  if (players.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center opacity-40">
+        <div className="mb-2 h-1 w-12 bg-text-muted" />
+        <span className="text-[0.625rem] font-black uppercase tracking-widest text-text-muted">
+          No players active
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {scenes.map(scene => (
+        <div key={scene} className="flex flex-col gap-2">
+          <button 
+            onClick={() => onSceneClick(scene)}
+            className="flex items-center gap-2 group w-full text-left"
+          >
+            <span className="text-[0.625rem] font-black uppercase tracking-widest text-accent group-hover:underline">
+              {scene}
+            </span>
+            <div className="h-[2px] flex-1 bg-black/10 group-hover:bg-accent/30" />
+            <span className="text-[0.625rem] font-black text-text-muted">
+              {playersByScene[scene].length}
+            </span>
+          </button>
+          
+          <div className="grid grid-cols-1 gap-2">
+            {playersByScene[scene].map(player => {
+              const staleAge = player.last_seen ? (Date.now() - player.last_seen * 1000) / 1000 : 0;
+              return (
+                <PlayerCard 
+                  key={player.player_id}
+                  hb={player} 
+                  isActive={false} 
+                  onClick={() => onPlayerClick(player.player_id)}
+                  staleAge={staleAge}
+                />
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/dashboard/src/components/BreadcrumbNav.tsx
+++ b/dashboard/src/components/BreadcrumbNav.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { ChevronRight, Home } from 'lucide-react';
+import type { NavStackItem } from '../types';
+
+interface BreadcrumbNavProps {
+  stack: NavStackItem[];
+  onNavigate: (index: number) => void;
+  onHome: () => void;
+}
+
+export const BreadcrumbNav: React.FC<BreadcrumbNavProps> = ({ stack, onNavigate, onHome }) => {
+  return (
+    <nav className="flex items-center gap-2 px-4 py-2 text-[0.625rem] font-black uppercase tracking-widest text-text-muted bg-bg-primary border-b-2 border-black/10">
+      <button 
+        onClick={onHome}
+        className="flex items-center gap-1 hover:text-accent transition-colors"
+      >
+        <Home size={12} />
+        <span>Cockpit</span>
+      </button>
+
+      {stack.map((item, i) => (
+        <React.Fragment key={i}>
+          <ChevronRight size={10} className="opacity-40" />
+          <button
+            onClick={() => onNavigate(i)}
+            className={`hover:text-accent transition-colors ${i === stack.length - 1 ? 'text-text-primary' : ''}`}
+          >
+            {item.label || item.view || item.tab}
+          </button>
+        </React.Fragment>
+      ))}
+    </nav>
+  );
+};

--- a/dashboard/src/components/CockpitGrid.tsx
+++ b/dashboard/src/components/CockpitGrid.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+
+interface CockpitGridProps {
+  // Expected order: [ActivePlayers, MainView (Map), Scoreboard, EventTimeline]
+  children: React.ReactNode[];
+  storageKey?: string;
+}
+
+export const CockpitGrid: React.FC<CockpitGridProps> = ({ children, storageKey }) => {
+  // Mobile layout (single column scroll)
+  const mobileLayout = (
+    <div className="flex flex-col gap-4 p-4 lg:hidden">
+      {children.map((child, i) => (
+        <div key={i}>{child}</div>
+      ))}
+    </div>
+  );
+
+  // Desktop layout (2 columns with resizable split)
+  const desktopLayout = (
+    <div className="hidden h-full w-full lg:block">
+      <PanelGroup direction="horizontal" autoSaveId={storageKey ? `${storageKey}_horizontal` : undefined}>
+        {/* Left Column */}
+        <Panel defaultSize={35} minSize={20}>
+          <div className="flex h-full flex-col gap-4 overflow-y-auto p-4">
+            <div className="flex-none">{children[0]}</div>
+            <div className="flex-1 min-h-0">{children[2]}</div>
+          </div>
+        </Panel>
+
+        <PanelResizeHandle className="group relative w-2 bg-bg-primary transition-colors hover:bg-accent/20">
+          <div className="absolute inset-y-0 left-1/2 w-[2px] -translate-x-1/2 bg-black/40 group-hover:bg-accent" />
+        </PanelResizeHandle>
+
+        {/* Right Column */}
+        <Panel defaultSize={65}>
+          <PanelGroup direction="vertical" autoSaveId={storageKey ? `${storageKey}_vertical` : undefined}>
+            <Panel defaultSize={60} minSize={30}>
+              <div className="h-full p-4 pl-0">
+                {children[1]}
+              </div>
+            </Panel>
+            
+            <PanelResizeHandle className="group relative h-2 bg-bg-primary transition-colors hover:bg-accent/20">
+              <div className="absolute inset-x-0 top-1/2 h-[2px] -translate-y-1/2 bg-black/40 group-hover:bg-accent" />
+            </PanelResizeHandle>
+
+            <Panel defaultSize={40}>
+              <div className="h-full overflow-y-auto p-4 pl-0 pt-0">
+                {children[3]}
+              </div>
+            </Panel>
+          </PanelGroup>
+        </Panel>
+      </PanelGroup>
+    </div>
+  );
+
+  return (
+    <div className="h-full w-full overflow-hidden">
+      {mobileLayout}
+      {desktopLayout}
+    </div>
+  );
+};

--- a/dashboard/src/components/CockpitPanel.tsx
+++ b/dashboard/src/components/CockpitPanel.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { CollapsibleCard } from './retro/CollapsibleCard';
+
+interface CockpitPanelProps {
+  children: React.ReactNode;
+  title: string;
+  storageKey: string;
+  defaultOpen?: boolean;
+  count?: number;
+  className?: string;
+  resizable?: boolean;
+  initialHeight?: number;
+}
+
+export const CockpitPanel: React.FC<CockpitPanelProps> = ({
+  children,
+  title,
+  storageKey,
+  defaultOpen = true,
+  count,
+  className = '',
+  resizable = false,
+  initialHeight,
+}) => {
+  return (
+    <CollapsibleCard
+      title={title}
+      storageKey={storageKey}
+      defaultOpen={defaultOpen}
+      count={count}
+      className={`h-full ${className}`}
+      resizable={resizable}
+      initialHeight={initialHeight}
+    >
+      <div className="p-4 h-full overflow-auto">
+        {children}
+      </div>
+    </CollapsibleCard>
+  );
+};

--- a/dashboard/src/components/DashboardLayout.tsx
+++ b/dashboard/src/components/DashboardLayout.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { Activity, Map, Clock, Users, LogOut, Globe, Settings } from 'lucide-react';
-import { RetroTabs } from './retro';
+import { LogOut, Users, Settings } from 'lucide-react';
 import { buildLabel } from '../lib/buildLabels';
+import { NavigationRail } from './NavigationRail';
+import type { Tab } from '../types';
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
   onLogout: () => void;
   isConnected: boolean;
-  activeTab: string;
-  setActiveTab: (tab: any) => void;
+  activeTab: Tab;
+  setActiveTab: (tab: Tab) => void;
   playerCount: number;
   playerCountLabel?: string;
   onPlayersClick: () => void;
@@ -34,10 +35,11 @@ interface DashboardLayoutProps {
   // Optional second-level bar rendered just above the bottom nav (e.g. the
   // Live-tab view switcher). Hidden when not provided.
   secondaryNav?: React.ReactNode;
+  filterBar?: React.ReactNode;
+  breadcrumb?: React.ReactNode;
 }
 
-// Unified mobile-first layout: fixed header + fixed bottom nav, scrollable
-// content in between. The same structure scales up to desktop (just wider).
+// Unified layout with NavigationRail (desktop side, mobile bottom)
 export const DashboardLayout: React.FC<DashboardLayoutProps> = ({
   children,
   onLogout,
@@ -57,6 +59,8 @@ export const DashboardLayout: React.FC<DashboardLayoutProps> = ({
   dashboardDeployedAt,
   latestPublished,
   secondaryNav,
+  filterBar,
+  breadcrumb,
 }) => {
   const publishedLabel = buildLabel(latestPublished);
   const fmtDate = (sec?: number | null) => (
@@ -67,95 +71,96 @@ export const DashboardLayout: React.FC<DashboardLayoutProps> = ({
       minute: '2-digit',
     }) : ''
   );
-  // Deploy date of this dashboard build, shown next to its version so "which
-  // version" reads as a human date, not just a hash.
   const dashDate = fmtDate(dashboardDeployedAt);
   const publishedDate = fmtDate(latestPublished?.timestamp);
-  const tabs = [
-    { id: 'live', label: 'Live', icon: <Activity size={24} /> },
-    { id: 'mapa', label: 'Globe', icon: <Globe size={24} /> },
-    { id: 'heatmap', label: 'Heatmap', icon: <Map size={24} /> },
-    { id: 'history', label: 'History', icon: <Clock size={24} /> },
-  ];
 
   return (
-    <div className="flex flex-col h-screen bg-bg-primary overflow-hidden font-mono crt-effect">
-      {/* Fixed header */}
-      <header className="relative shrink-0 flex flex-col gap-2 px-3 py-2 border-b-4 border-black bg-bg-card z-30 sm:flex-row sm:items-center sm:justify-between sm:px-4">
-        <h1 className="text-accent font-black text-sm italic leading-none tracking-tighter sm:text-base">
-          <button type="button" onClick={() => setActiveTab('live')} className="hover:text-text-primary">
-            <span className="block sm:inline">ODISEA</span>
-          </button>
-          <span className="ml-2 align-middle text-[0.5rem] font-bold not-italic tracking-normal text-text-muted">
-            dash {dashboardVersion || 'dev'}{dashDate ? ` (${dashDate})` : ''}
-            {publishedLabel ? (
-              <> · pub {publishedLabel}{publishedDate ? ` (${publishedDate})` : ''}</>
-            ) : null}
-          </span>
-        </h1>
+    <div className="flex h-screen w-screen bg-bg-primary overflow-hidden font-mono crt-effect">
+      {/* Desktop side navigation */}
+      <NavigationRail activeTab={activeTab} onTabChange={setActiveTab} className="hidden lg:flex" />
 
-        <div className="flex min-w-0 items-center justify-between gap-2 sm:justify-end sm:gap-4">
-          {activePlayerMeta}
-          {headerControls}
+      <div className="flex flex-1 flex-col min-w-0">
+        {/* Fixed header */}
+        <header className="relative shrink-0 flex flex-col gap-2 px-3 py-2 border-b-4 border-black bg-bg-card z-30 sm:flex-row sm:items-center sm:justify-between sm:px-4">
+          <h1 className="text-accent font-black text-sm italic leading-none tracking-tighter sm:text-base">
+            <button type="button" onClick={() => setActiveTab('dashboard')} className="hover:text-text-primary">
+              <span className="block sm:inline">ODISEA</span>
+            </button>
+            <span className="ml-2 align-middle text-[0.5rem] font-bold not-italic tracking-normal text-text-muted">
+              dash {dashboardVersion || 'dev'}{dashDate ? ` (${dashDate})` : ''}
+              {publishedLabel ? (
+                <> · pub {publishedLabel}{publishedDate ? ` (${publishedDate})` : ''}</>
+              ) : null}
+            </span>
+          </h1>
 
-          <span className="flex items-center gap-1.5 text-[0.625rem] uppercase font-bold">
-            <span className={`w-2 h-2 rounded-full ${isConnected ? 'bg-success shadow-[0_0_8px_rgba(63,185,80,0.5)]' : 'bg-danger'}`} />
-            <span className={isConnected ? 'text-success' : 'text-danger'}>{isConnected ? 'on' : 'off'}</span>
-          </span>
+          <div className="flex min-w-0 items-center justify-between gap-2 sm:justify-end sm:gap-4">
+            {activePlayerMeta}
+            {headerControls}
 
-          {/* Player count -> opens the bottom sheet */}
-          <button
-            onClick={onToggleSettings}
-            className="p-1.5 border-2 border-black bg-bg-primary hover:bg-accent hover:text-black transition-colors"
-            title="Settings"
-          >
-            <Settings size={14} />
-          </button>
+            <span className="flex items-center gap-1.5 text-[0.625rem] uppercase font-bold">
+              <span className={`w-2 h-2 rounded-full ${isConnected ? 'bg-success shadow-[0_0_8px_rgba(63,185,80,0.5)]' : 'bg-danger'}`} />
+              <span className={isConnected ? 'text-success' : 'text-danger'}>{isConnected ? 'on' : 'off'}</span>
+            </span>
 
-          <button
-            onClick={onPlayersClick}
-            className="flex items-center gap-1.5 px-2 py-1 border-2 border-black bg-bg-primary text-[0.625rem] font-bold uppercase hover:bg-accent hover:text-black transition-colors"
-          >
-            <Users size={14} />
-            {playerCountLabel || `${playerCount} ${playerCount === 1 ? 'player' : 'players'}`}
-          </button>
+            <button
+              onClick={onToggleSettings}
+              className="p-1.5 border-2 border-black bg-bg-primary hover:bg-accent hover:text-black transition-colors"
+              title="Settings"
+            >
+              <Settings size={14} />
+            </button>
 
-          <button
-            onClick={onLogout}
-            className="p-1.5 border-2 border-black bg-bg-primary hover:bg-danger hover:text-black transition-colors"
-            title="Log out"
-          >
-            <LogOut size={14} />
-          </button>
+            <button
+              onClick={onPlayersClick}
+              className="flex items-center gap-1.5 px-2 py-1 border-2 border-black bg-bg-primary text-[0.625rem] font-bold uppercase hover:bg-accent hover:text-black transition-colors"
+            >
+              <Users size={14} />
+              <span className="hidden sm:inline">{playerCountLabel || `${playerCount} ${playerCount === 1 ? 'player' : 'players'}`}</span>
+              <span className="sm:hidden">{playerCount}</span>
+            </button>
+
+            <button
+              onClick={onLogout}
+              className="p-1.5 border-2 border-black bg-bg-primary hover:bg-danger hover:text-black transition-colors"
+              title="Log out"
+            >
+              <LogOut size={14} />
+            </button>
+          </div>
+          {playerFocus && (
+            <div className="fixed right-2 top-2 z-50 sm:absolute sm:left-1/2 sm:right-auto sm:top-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2">
+              {playerFocus}
+            </div>
+          )}
+        </header>
+
+        {/* Breadcrumb & Filter Bar */}
+        <div className="shrink-0 flex flex-col">
+          {breadcrumb}
+          {filterBar}
         </div>
-        {playerFocus && (
-          <div className="fixed right-2 top-2 z-50 sm:absolute sm:left-1/2 sm:right-auto sm:top-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2">
-            {playerFocus}
+
+        {/* Scrollable content */}
+        <main className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden relative">
+          {showSettings && settingsPanel && (
+            <div className="sticky top-0 z-20 bg-bg-card border-b-2 border-black px-3 py-3">
+              {settingsPanel}
+            </div>
+          )}
+          {children}
+        </main>
+
+        {/* Optional second-level bar */}
+        {secondaryNav && (
+          <div className="shrink-0 border-t-2 border-black bg-bg-card/80 z-30">
+            {secondaryNav}
           </div>
         )}
-      </header>
 
-      {/* Scrollable content */}
-      <main className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
-        {showSettings && settingsPanel && (
-          <div className="sticky top-0 z-20 bg-bg-card border-b-2 border-black px-3 py-3">
-            {settingsPanel}
-          </div>
-        )}
-        {children}
-      </main>
-
-      {/* Optional second-level bar (e.g. Live view switcher) */}
-      {secondaryNav && (
-        <div className="shrink-0 border-t-2 border-black bg-bg-card/80 z-30">
-          {secondaryNav}
-        </div>
-      )}
-
-      {/* Fixed bottom nav */}
-      <nav className="shrink-0 border-t-4 border-black bg-bg-card z-30">
-        <RetroTabs tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
-      </nav>
+        {/* Mobile bottom navigation */}
+        <NavigationRail activeTab={activeTab} onTabChange={setActiveTab} className="lg:hidden" isMobile />
+      </div>
     </div>
   );
 };

--- a/dashboard/src/components/EventTimeline.tsx
+++ b/dashboard/src/components/EventTimeline.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { UserPlus, UserMinus, Flame, AlertTriangle } from 'lucide-react';
+
+interface TimelineEvent {
+  id: string;
+  type: 'connect' | 'disconnect' | 'hotzone' | 'alert';
+  playerId: string;
+  playerName: string;
+  timestamp: number;
+  message: string;
+  scene?: string;
+}
+
+interface EventTimelineProps {
+  events: TimelineEvent[];
+}
+
+export const EventTimeline: React.FC<EventTimelineProps> = ({ events }) => {
+  if (events.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-8 text-xs italic text-text-muted">
+        No hay eventos recientes
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      {events.map((event, i) => (
+        <div 
+          key={event.id} 
+          className={`flex gap-3 px-3 py-2 border-l-2 transition-colors hover:bg-bg-primary/50 ${
+            i !== events.length - 1 ? 'border-b border-black/5' : ''
+          } ${
+            event.type === 'hotzone' ? 'border-l-warning' :
+            event.type === 'alert' ? 'border-l-danger' :
+            'border-l-accent'
+          }`}
+        >
+          <div className="shrink-0 mt-0.5">
+            {event.type === 'connect' && <UserPlus size={14} className="text-success" />}
+            {event.type === 'disconnect' && <UserMinus size={14} className="text-danger" />}
+            {event.type === 'hotzone' && <Flame size={14} className="text-warning" />}
+            {event.type === 'alert' && <AlertTriangle size={14} className="text-danger" />}
+          </div>
+          
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate text-[0.625rem] font-black uppercase text-text-primary">
+                {event.playerName || event.playerId.slice(0, 8)}
+              </span>
+              <span className="shrink-0 text-[0.5rem] font-mono text-text-muted">
+                {new Date(event.timestamp * 1000).toLocaleTimeString('es', { 
+                  hour: '2-digit', 
+                  minute: '2-digit',
+                  second: '2-digit'
+                })}
+              </span>
+            </div>
+            <div className="truncate text-[0.625rem] text-text-muted mt-0.5">
+              {event.message}
+              {event.scene && <span className="text-accent ml-1">· {event.scene}</span>}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/dashboard/src/components/GlobalFilterBar.tsx
+++ b/dashboard/src/components/GlobalFilterBar.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { X, Plus, Flame } from 'lucide-react';
+import { PLATFORM_META } from './PlatformFilter';
+
+interface GlobalFilterBarProps {
+  selectedScene: string;
+  selectedPlatforms: Set<string>;
+  selectedCountry: string;
+  warmupSeconds: number;
+  onRemoveScene: () => void;
+  onTogglePlatform: (platform: string) => void;
+  onRemoveCountry: () => void;
+  onToggleWarmup: () => void;
+  onOpenFilters: () => void;
+  allPlatforms: string[];
+}
+
+export const GlobalFilterBar: React.FC<GlobalFilterBarProps> = ({
+  selectedScene,
+  selectedPlatforms,
+  selectedCountry,
+  warmupSeconds,
+  onRemoveScene,
+  onTogglePlatform,
+  onRemoveCountry,
+  onToggleWarmup,
+  onOpenFilters,
+  allPlatforms,
+}) => {
+  const isAllPlatforms = selectedPlatforms.size === allPlatforms.filter(p => p !== 'server').length;
+  
+  return (
+    <div className="flex items-center gap-2 border-b-2 border-black bg-bg-card px-3 py-1.5 overflow-x-auto no-scrollbar">
+      <div className="flex items-center gap-1.5 whitespace-nowrap">
+        {selectedScene !== 'all' && (
+          <FilterChip label={`Escena: ${selectedScene}`} onRemove={onRemoveScene} />
+        )}
+        
+        {!isAllPlatforms && Array.from(selectedPlatforms).map(p => (
+          <FilterChip 
+            key={p} 
+            label={PLATFORM_META[p]?.label || p} 
+            onRemove={() => onTogglePlatform(p)} 
+            icon={PLATFORM_META[p]?.icon}
+          />
+        ))}
+
+        {selectedCountry !== 'all' && (
+          <FilterChip label={`País: ${selectedCountry}`} onRemove={onRemoveCountry} />
+        )}
+
+        {warmupSeconds > 0 && (
+          <FilterChip 
+            label={`Warmup: ${warmupSeconds}s`} 
+            onRemove={onToggleWarmup} 
+            icon={<Flame size={12} className="text-warning" />}
+          />
+        )}
+
+        <button
+          onClick={onOpenFilters}
+          className="flex items-center gap-1 border-2 border-dashed border-black/30 px-2 py-1 text-[0.625rem] font-black uppercase text-text-muted hover:border-accent hover:text-accent transition-colors"
+        >
+          <Plus size={12} />
+          <span>Añadir filtro</span>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const FilterChip: React.FC<{ label: string; onRemove: () => void; icon?: React.ReactNode }> = ({ label, onRemove, icon }) => (
+  <div className="flex items-center gap-1.5 border-2 border-black bg-bg-primary px-2 py-1 text-[0.625rem] font-black uppercase shadow-[1px_1px_0px_0px_black]">
+    {icon}
+    <span>{label}</span>
+    <button onClick={onRemove} className="text-text-muted hover:text-danger">
+      <X size={12} />
+    </button>
+  </div>
+);

--- a/dashboard/src/components/NavigationRail.tsx
+++ b/dashboard/src/components/NavigationRail.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { LayoutDashboard, Box, Users, BarChart2, Video } from 'lucide-react';
+import type { Tab } from '../types';
+
+interface NavigationRailProps {
+  activeTab: Tab;
+  onTabChange: (tab: Tab) => void;
+  className?: string;
+  isMobile?: boolean;
+}
+
+const NAV_ITEMS: { id: Tab; label: string; icon: React.FC<any> }[] = [
+  { id: 'dashboard', label: 'Cockpit', icon: LayoutDashboard },
+  { id: 'scenes', label: 'Scenes', icon: Box },
+  { id: 'players', label: 'Players', icon: Users },
+  { id: 'analysis', label: 'Analysis', icon: BarChart2 },
+  { id: 'replays', label: 'Replays', icon: Video },
+];
+
+export const NavigationRail: React.FC<NavigationRailProps> = ({ activeTab, onTabChange, className = '', isMobile = false }) => {
+  if (isMobile) {
+    return (
+      <nav className={`fixed bottom-0 left-0 right-0 z-[100] border-t-4 border-black bg-bg-card flex justify-around py-1 ${className}`}>
+        {NAV_ITEMS.map((item) => {
+          const Icon = item.icon;
+          const isActive = activeTab === item.id;
+          return (
+            <button
+              key={item.id}
+              onClick={() => onTabChange(item.id)}
+              className={`flex flex-col items-center gap-1 p-2 min-w-[64px] ${isActive ? 'text-accent' : 'text-text-muted hover:text-text-primary'}`}
+            >
+              <Icon size={20} />
+              <span className="text-[0.5rem] font-black uppercase tracking-tighter">{item.label}</span>
+            </button>
+          );
+        })}
+      </nav>
+    );
+  }
+
+  return (
+    <aside className={`flex w-20 flex-col items-center border-r-4 border-black bg-bg-card py-4 gap-6 ${className}`}>
+      {NAV_ITEMS.map((item) => {
+        const Icon = item.icon;
+        const isActive = activeTab === item.id;
+        return (
+          <button
+            key={item.id}
+            onClick={() => onTabChange(item.id)}
+            className={`group relative flex flex-col items-center gap-1 transition-colors ${isActive ? 'text-accent' : 'text-text-muted hover:text-text-primary'}`}
+            title={item.label}
+          >
+            <div className={`p-2 border-2 transition-all ${isActive ? 'border-accent bg-accent/10 shadow-[2px_2px_0px_0px_black]' : 'border-transparent group-hover:border-black/20'}`}>
+              <Icon size={24} />
+            </div>
+            <span className="text-[0.5rem] font-black uppercase tracking-widest">{item.label}</span>
+            {isActive && (
+              <div className="absolute -left-4 top-1/2 h-8 w-1 -translate-y-1/2 bg-accent" />
+            )}
+          </button>
+        );
+      })}
+    </aside>
+  );
+};

--- a/dashboard/src/components/PlayerHealthCard.tsx
+++ b/dashboard/src/components/PlayerHealthCard.tsx
@@ -1,0 +1,110 @@
+import React, { useMemo } from 'react';
+import { ResponsiveContainer, LineChart, Line, YAxis } from 'recharts';
+import { Activity, Zap, Info } from 'lucide-react';
+
+interface PlayerHealthCardProps {
+  playerId: string;
+  displayName?: string;
+  fps: number;
+  fpsHistory: number[];
+  platform: string;
+  scene: string;
+  status: 'ok' | 'warning' | 'critical';
+  targetFps?: number;
+}
+
+const PLATFORM_TARGETS: Record<string, number> = {
+  'linux': 60,
+  'windows': 60,
+  'android': 30,
+  'web': 60,
+  'html5': 60,
+};
+
+export const PlayerHealthCard: React.FC<PlayerHealthCardProps> = ({
+  fps,
+  fpsHistory,
+  platform,
+  scene,
+  status,
+  targetFps,
+}) => {
+  const target = targetFps || PLATFORM_TARGETS[platform.toLowerCase()] || 60;
+  
+  const sparkData = useMemo(() => 
+    fpsHistory.map((n, i) => ({ i, n })), 
+  [fpsHistory]);
+
+  const statusColor = {
+    ok: 'text-success',
+    warning: 'text-warning',
+    critical: 'text-danger',
+  }[status];
+
+  const bgColor = {
+    ok: 'bg-success/5',
+    warning: 'bg-warning/5',
+    critical: 'bg-danger/5',
+  }[status];
+
+  const borderColor = {
+    ok: 'border-success/30',
+    warning: 'border-warning/30',
+    critical: 'border-danger/30',
+  }[status];
+
+  return (
+    <div className={`flex flex-col gap-4 border-2 p-4 shadow-[2px_2px_0px_0px_black] transition-colors ${borderColor} ${bgColor}`}>
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="flex items-center gap-2 mb-1">
+            <Activity size={14} className={statusColor} />
+            <span className="text-[0.625rem] font-black uppercase tracking-widest text-text-muted">Health Status</span>
+          </div>
+          <div className={`text-4xl font-black tracking-tighter ${statusColor}`}>
+            {Math.round(fps)} <span className="text-sm font-bold uppercase tracking-normal opacity-50">FPS</span>
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-[0.5rem] font-black uppercase tracking-widest text-text-muted mb-1">Target</div>
+          <div className="border-2 border-black bg-bg-primary px-2 py-0.5 text-xs font-black">
+            {target}
+          </div>
+        </div>
+      </div>
+
+      <div className="h-16 w-full border-b border-black/10 pb-2">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={sparkData}>
+            <YAxis hide domain={[0, Math.max(target + 10, ...fpsHistory, 60)]} />
+            <Line 
+              type="monotone" 
+              dataKey="n" 
+              stroke={status === 'ok' ? '#3fb950' : status === 'warning' ? '#d29922' : '#f85149'} 
+              dot={false} 
+              strokeWidth={2} 
+              isAnimationActive={false} 
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-1 text-[0.5rem] font-black uppercase text-text-muted">
+            <Zap size={10} />
+            Platform
+          </div>
+          <div className="truncate text-[0.625rem] font-bold uppercase">{platform}</div>
+        </div>
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-1 text-[0.5rem] font-black uppercase text-text-muted">
+            <Info size={10} />
+            Scene
+          </div>
+          <div className="truncate text-[0.625rem] font-bold uppercase text-accent">{scene}</div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/dashboard/src/components/SceneHealthCard.tsx
+++ b/dashboard/src/components/SceneHealthCard.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Activity, Users, Flame, ChevronRight, AlertTriangle } from 'lucide-react';
+import { SceneHealth } from '../types';
+
+interface SceneHealthCardProps {
+  health: SceneHealth;
+  onClick: () => void;
+}
+
+export const SceneHealthCard: React.FC<SceneHealthCardProps> = ({ health, onClick }) => {
+  const fpsColor = (fps: number) => {
+    if (fps > 45) return 'text-success';
+    if (fps >= 30) return 'text-warning';
+    return 'text-danger';
+  };
+
+  const statusTone = health.avg_fps > 45 ? 'bg-success/5 border-success/30' : 
+                     health.avg_fps >= 30 ? 'bg-warning/5 border-warning/30' : 
+                     'bg-danger/5 border-danger/30';
+
+  return (
+    <button
+      onClick={onClick}
+      className={`group flex flex-col gap-3 border-2 p-4 text-left shadow-[2px_2px_0px_0px_black] transition-all hover:bg-accent/5 ${statusTone}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <Activity size={14} className="text-accent" />
+            <span className="truncate text-xs font-black uppercase text-accent">{health.scene_id}</span>
+          </div>
+          {health.last_event && (
+            <div className="flex items-center gap-1 text-[0.5rem] font-bold uppercase text-text-muted">
+               <AlertTriangle size={10} className="text-warning" />
+               {health.last_event}
+            </div>
+          )}
+        </div>
+        <div className="text-right">
+          <div className={`text-xl font-black tracking-tighter ${fpsColor(health.avg_fps)}`}>
+            {Math.round(health.avg_fps)}
+          </div>
+          <div className="text-[0.5rem] font-black uppercase text-text-muted">avg fps</div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 border-t border-black/10 pt-3">
+        <div className="flex flex-col">
+          <div className="flex items-center gap-1 text-[0.5rem] font-black uppercase text-text-muted">
+            <Users size={10} />
+            Live
+          </div>
+          <div className="text-[0.625rem] font-black">{health.active_players}</div>
+        </div>
+        <div className="flex flex-col">
+          <div className="flex items-center gap-1 text-[0.5rem] font-black uppercase text-text-muted">
+            <Flame size={10} />
+            Hotzones
+          </div>
+          <div className="text-[0.625rem] font-black">{health.hotzone_count}</div>
+        </div>
+        <div className="flex flex-col">
+          <div className="flex items-center gap-1 text-[0.5rem] font-black uppercase text-text-muted">
+            Build
+          </div>
+          <div className="truncate text-[0.5rem] font-mono text-text-muted/70">{health.latest_build.slice(0, 7)}</div>
+        </div>
+      </div>
+
+      <div className="mt-1 flex items-center justify-end gap-1 text-[0.5rem] font-black uppercase text-accent opacity-0 transition-opacity group-hover:opacity-100">
+        Ver Detalle
+        <ChevronRight size={10} />
+      </div>
+    </button>
+  );
+};

--- a/dashboard/src/hooks/useLayoutPersistence.ts
+++ b/dashboard/src/hooks/useLayoutPersistence.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
+import type { NavStackItem } from '../types';
 
 const STORAGE_KEY = 'odisea_dashboard_layout';
-const LAYOUT_VERSION = 2;
+const LAYOUT_VERSION = 3;
 const DEFAULT_MIN_DURATION = 13;
 
 export interface LayoutState {
@@ -14,16 +15,24 @@ export interface LayoutState {
   filtersCollapsed: boolean;
   // History min-duration filter (seconds); excludes shorter sessions.
   historyMinDuration: number;
+  // Navigation stack for drilldown preservation
+  navStack: NavStackItem[];
+  // Persisted state for cockpit panels
+  cockpitPanelStates: Record<string, boolean>;
+  cockpitPanelSizes: Record<string, number>;
 }
 
 const DEFAULT_STATE: LayoutState = {
   version: LAYOUT_VERSION,
   panelSizes: [20, 80],
-  activeTab: 'live',
+  activeTab: 'dashboard',
   sidebarCollapsed: false,
   accelerometerEnabled: false,
   filtersCollapsed: false,
   historyMinDuration: DEFAULT_MIN_DURATION,
+  navStack: [],
+  cockpitPanelStates: {},
+  cockpitPanelSizes: {},
 };
 
 export function useLayoutPersistence() {

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -45,7 +45,30 @@ export type HeartbeatMap = Record<string, Heartbeat>;
 
 // Top-level dashboard tabs. Shared so components (e.g. Viewport3D) can type
 // their setActiveTab prop against the same union instead of a loose `string`.
-export type Tab = 'live' | 'heatmap' | 'history' | 'mapa';
+export type Tab = 'dashboard' | 'scenes' | 'players' | 'analysis' | 'replays' | 'live' | 'heatmap' | 'history' | 'mapa';
+
+export interface NavStackItem {
+  tab: Tab;
+  view?: string;
+  params?: Record<string, any>;
+  label?: string;
+}
+
+export interface SceneHealth {
+  scene_id: string;
+  avg_fps: number;
+  min_fps: number;
+  active_players: number;
+  hotzone_count: number;
+  latest_build: string;
+  last_event?: string;
+}
+
+export interface HotzonePriority {
+  id: string;
+  score: number;
+  reasons: string[];
+}
 
 export interface Alert {
   id: string;


### PR DESCRIPTION
Implementación de la Sesión A de Jules para FD-227.

**13 archivos modificados:**
- Refactor App.tsx: reemplaza tabs live/heatmap/history/mapa por dashboard/scenes/players/analysis/replays
- CockpitGrid + CockpitPanel: layout responsive con react-resizable-panels
- ActivePlayersGrid: players agrupados por escena
- PlayerHealthCard: FPS con sparkline + targets por plataforma
- NavigationRail: desktop side + mobile bottom nav
- GlobalFilterBar: chips de filtros activos con warmup
- EventTimeline: timeline de eventos recientes
- BreadcrumbNav: breadcrumb contextual
- SceneHealthCard: card de salud de escena
- DashboardLayout: integra NavigationRail + filterBar + breadcrumb
- types/useLayoutPersistence: nuevo Tab, NavStack, SceneHealth tipos

**Base:** FD v1 + comments de Sebastian